### PR TITLE
Add patient editing and deletion

### DIFF
--- a/M8MED/package-lock.json
+++ b/M8MED/package-lock.json
@@ -8,6 +8,8 @@
       "name": "m8med",
       "version": "0.0.0",
       "dependencies": {
+        "@headlessui/react": "^2.2.6",
+        "@heroicons/react": "^2.2.0",
         "formik": "^2.4.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -939,6 +941,88 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.2.tgz",
+      "integrity": "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.2.tgz",
+      "integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.2",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.4.tgz",
+      "integrity": "sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
+    "node_modules/@headlessui/react": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.6.tgz",
+      "integrity": "sha512-gN5CT8Kf4IWwL04GQOjZ/ZnHMFoeFHZmVSFoDKeTmbtmy9oFqQqJMthdBiO3Pl5LXk2w03fGFLpQV6EW84vjjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/interactions": "^3.25.0",
+        "@tanstack/react-virtual": "^3.13.9",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1109,6 +1193,103 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.0.tgz",
+      "integrity": "sha512-7NEGtTPsBy52EZ/ToVKCu0HSelE3kq9qeis+2eEq90XSuJOMaDHUQrA7RC2Y89tlEwQB31bud/kKRi9Qme1dkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/utils": "^3.30.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.25.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.4.tgz",
+      "integrity": "sha512-HBQMxgUPHrW8V63u9uGgBymkMfj6vdWbB0GgUJY49K9mBKMsypcHeWkWM6+bF7kxRO728/IK8bWDV6whDbqjHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/flags": "^3.1.2",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
+      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.30.0.tgz",
+      "integrity": "sha512-ydA6y5G1+gbem3Va2nczj/0G0W7/jUVo/cbN10WA5IizzWIwMP5qhFr7macgbKfHMkZ+YZC3oXnt2NNre5odKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
+      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.10.8",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.8.tgz",
+      "integrity": "sha512-SN3/h7SzRsusVQjQ4v10LaVsDc81jyyR0DD5HnsQitm/I5WDpaSr2nRHtyloPFU48jlql1XX/S04T2DLQM7Y3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.31.0.tgz",
+      "integrity": "sha512-ua5U6V66gDcbLZe4P2QeyNgPp4YWD1ymGA6j3n+s8CGExtrCPe64v+g4mvpT8Bnb985R96e4zFT61+m0YCwqMg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@remix-run/router": {
@@ -1406,6 +1587,42 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2109,6 +2326,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -4056,6 +4282,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
@@ -4321,6 +4553,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/M8MED/package.json
+++ b/M8MED/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@headlessui/react": "^2.2.6",
+    "@heroicons/react": "^2.2.0",
     "formik": "^2.4.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/M8MED/src/App.tsx
+++ b/M8MED/src/App.tsx
@@ -1,19 +1,19 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
-import Landing from './pages/Landing'
-import Login from './pages/Login'
-import DashboardAdmin from './pages/DashboardAdmin'
-import DashboardMedico from './pages/DashboardMedico'
-import Pacientes from './pages/Pacientes'
-import AgregarPaciente from './pages/AgregarPaciente'
-import EditarPaciente from './pages/EditarPaciente'
-import NewSurgery from './pages/NewSurgery'
-import EditComplexity from './pages/EditComplexity'
-import Summary from './pages/Summary'
-import GeneralSummary from './pages/GeneralSummary'
-import AgregarDoctor from './pages/AgregarDoctor'
-import PerfilUsuario from './pages/PerfilUsuario'
-import ProtectedRoute from './routes/ProtectedRoute'
-import Turnos from './pages/Turnos'
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Landing from './pages/Landing';
+import Login from './pages/Login';
+import DashboardAdmin from './pages/DashboardAdmin';
+import DashboardMedico from './pages/DashboardMedico';
+import Pacientes from './pages/Pacientes';
+import AgregarPaciente from './pages/AgregarPaciente';
+import EditarPaciente from './pages/EditarPaciente';
+import NewSurgery from './pages/NewSurgery';
+import EditComplexity from './pages/EditComplexity';
+import Summary from './pages/Summary';
+import GeneralSummary from './pages/GeneralSummary';
+import AgregarDoctor from './pages/AgregarDoctor';
+import PerfilUsuario from './pages/PerfilUsuario';
+import ProtectedRoute from './routes/ProtectedRoute';
+import Turnos from './pages/Turnos';
 
 export default function App() {
   return (
@@ -108,7 +108,7 @@ export default function App() {
         <Route
           path="/perfil"
           element={
-            <ProtectedRoute rolPermitido={["admin", "medico"]}>
+            <ProtectedRoute rolPermitido={['admin', 'medico']}>
               <PerfilUsuario />
             </ProtectedRoute>
           }
@@ -125,5 +125,5 @@ export default function App() {
         />
       </Routes>
     </BrowserRouter>
-  )
+  );
 }

--- a/M8MED/src/App.tsx
+++ b/M8MED/src/App.tsx
@@ -12,6 +12,7 @@ import Summary from './pages/Summary'
 import GeneralSummary from './pages/GeneralSummary'
 import PerfilUsuario from './pages/PerfilUsuario'
 import ProtectedRoute from './routes/ProtectedRoute'
+import Turnos from './pages/Turnos'
 
 export default function App() {
   return (
@@ -43,6 +44,14 @@ export default function App() {
           element={
             <ProtectedRoute rolPermitido="admin">
               <AgregarPaciente />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/turnos"
+          element={
+            <ProtectedRoute rolPermitido="admin">
+              <Turnos />
             </ProtectedRoute>
           }
         />

--- a/M8MED/src/App.tsx
+++ b/M8MED/src/App.tsx
@@ -10,6 +10,7 @@ import NewSurgery from './pages/NewSurgery'
 import EditComplexity from './pages/EditComplexity'
 import Summary from './pages/Summary'
 import GeneralSummary from './pages/GeneralSummary'
+import PerfilUsuario from './pages/PerfilUsuario'
 import ProtectedRoute from './routes/ProtectedRoute'
 
 export default function App() {
@@ -82,6 +83,15 @@ export default function App() {
           element={
             <ProtectedRoute rolPermitido="admin">
               <GeneralSummary />
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/perfil"
+          element={
+            <ProtectedRoute rolPermitido={["admin", "medico"]}>
+              <PerfilUsuario />
             </ProtectedRoute>
           }
         />

--- a/M8MED/src/App.tsx
+++ b/M8MED/src/App.tsx
@@ -5,6 +5,7 @@ import DashboardAdmin from './pages/DashboardAdmin'
 import DashboardMedico from './pages/DashboardMedico'
 import Pacientes from './pages/Pacientes'
 import AgregarPaciente from './pages/AgregarPaciente'
+import EditarPaciente from './pages/EditarPaciente'
 import NewSurgery from './pages/NewSurgery'
 import EditComplexity from './pages/EditComplexity'
 import Summary from './pages/Summary'
@@ -41,6 +42,14 @@ export default function App() {
           element={
             <ProtectedRoute rolPermitido="admin">
               <AgregarPaciente />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/pacientes/editar/:id"
+          element={
+            <ProtectedRoute rolPermitido="admin">
+              <EditarPaciente />
             </ProtectedRoute>
           }
         />

--- a/M8MED/src/App.tsx
+++ b/M8MED/src/App.tsx
@@ -10,6 +10,7 @@ import NewSurgery from './pages/NewSurgery'
 import EditComplexity from './pages/EditComplexity'
 import Summary from './pages/Summary'
 import GeneralSummary from './pages/GeneralSummary'
+import AgregarDoctor from './pages/AgregarDoctor'
 import PerfilUsuario from './pages/PerfilUsuario'
 import ProtectedRoute from './routes/ProtectedRoute'
 import Turnos from './pages/Turnos'
@@ -44,6 +45,14 @@ export default function App() {
           element={
             <ProtectedRoute rolPermitido="admin">
               <AgregarPaciente />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/agregar-medico"
+          element={
+            <ProtectedRoute rolPermitido="admin">
+              <AgregarDoctor />
             </ProtectedRoute>
           }
         />

--- a/M8MED/src/components/Calendar.tsx
+++ b/M8MED/src/components/Calendar.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react'
+import { meses } from '../lib/date'
+
+type Event = { date: string }
+
+type Props = {
+  events: Event[]
+}
+
+export default function Calendar({ events }: Props) {
+  const [current, setCurrent] = useState(() => new Date())
+
+  const month = current.getMonth()
+  const year = current.getFullYear()
+
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
+  const firstDay = new Date(year, month, 1).getDay()
+
+  const monthEvents = events.filter((e) => {
+    const d = new Date(e.date)
+    return d.getFullYear() === year && d.getMonth() === month
+  })
+  const eventDays = new Set(
+    monthEvents.map((e) => new Date(e.date).getDate())
+  )
+
+  const prevMonth = () => setCurrent(new Date(year, month - 1, 1))
+  const nextMonth = () => setCurrent(new Date(year, month + 1, 1))
+
+  return (
+    <div className="bg-white p-4 rounded-xl shadow w-full max-w-md">
+      <div className="flex justify-between items-center mb-2">
+        <button onClick={prevMonth} className="px-2">‹</button>
+        <span className="font-medium">
+          {meses[month].label} {year}
+        </span>
+        <button onClick={nextMonth} className="px-2">›</button>
+      </div>
+      <div className="grid grid-cols-7 gap-1 text-center text-sm">
+        {['Dom','Lun','Mar','Mié','Jue','Vie','Sáb'].map((d) => (
+          <div key={d} className="font-medium">
+            {d}
+          </div>
+        ))}
+        {Array.from({ length: firstDay }).map((_, i) => (
+          <div key={'b'+i}></div>
+        ))}
+        {Array.from({ length: daysInMonth }).map((_, i) => {
+          const day = i + 1
+          const hasEvent = eventDays.has(day)
+          return (
+            <div
+              key={day}
+              className={
+                'py-1 rounded ' + (hasEvent ? 'bg-blue-200 font-semibold' : '')
+              }
+            >
+              {day}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/M8MED/src/components/Calendar.tsx
+++ b/M8MED/src/components/Calendar.tsx
@@ -1,53 +1,55 @@
-import { useState } from 'react'
-import { meses } from '../lib/date'
+import { useState } from 'react';
+import { meses } from '../lib/date';
 
-type Event = { date: string }
+type Event = { date: string };
 
 type Props = {
-  events: Event[]
-}
+  events: Event[];
+};
 
 export default function Calendar({ events }: Props) {
-  const [current, setCurrent] = useState(() => new Date())
+  const [current, setCurrent] = useState(() => new Date());
 
-  const month = current.getMonth()
-  const year = current.getFullYear()
+  const month = current.getMonth();
+  const year = current.getFullYear();
 
-  const daysInMonth = new Date(year, month + 1, 0).getDate()
-  const firstDay = new Date(year, month, 1).getDay()
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const firstDay = new Date(year, month, 1).getDay();
 
   const monthEvents = events.filter((e) => {
-    const d = new Date(e.date)
-    return d.getFullYear() === year && d.getMonth() === month
-  })
-  const eventDays = new Set(
-    monthEvents.map((e) => new Date(e.date).getDate())
-  )
+    const d = new Date(e.date);
+    return d.getFullYear() === year && d.getMonth() === month;
+  });
+  const eventDays = new Set(monthEvents.map((e) => new Date(e.date).getDate()));
 
-  const prevMonth = () => setCurrent(new Date(year, month - 1, 1))
-  const nextMonth = () => setCurrent(new Date(year, month + 1, 1))
+  const prevMonth = () => setCurrent(new Date(year, month - 1, 1));
+  const nextMonth = () => setCurrent(new Date(year, month + 1, 1));
 
   return (
     <div className="bg-white p-4 rounded-xl shadow w-full max-w-md">
       <div className="flex justify-between items-center mb-2">
-        <button onClick={prevMonth} className="px-2">‹</button>
+        <button onClick={prevMonth} className="px-2">
+          ‹
+        </button>
         <span className="font-medium">
           {meses[month].label} {year}
         </span>
-        <button onClick={nextMonth} className="px-2">›</button>
+        <button onClick={nextMonth} className="px-2">
+          ›
+        </button>
       </div>
       <div className="grid grid-cols-7 gap-1 text-center text-sm">
-        {['Dom','Lun','Mar','Mié','Jue','Vie','Sáb'].map((d) => (
+        {['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'].map((d) => (
           <div key={d} className="font-medium">
             {d}
           </div>
         ))}
         {Array.from({ length: firstDay }).map((_, i) => (
-          <div key={'b'+i}></div>
+          <div key={'b' + i}></div>
         ))}
         {Array.from({ length: daysInMonth }).map((_, i) => {
-          const day = i + 1
-          const hasEvent = eventDays.has(day)
+          const day = i + 1;
+          const hasEvent = eventDays.has(day);
           return (
             <div
               key={day}
@@ -57,9 +59,9 @@ export default function Calendar({ events }: Props) {
             >
               {day}
             </div>
-          )
+          );
         })}
       </div>
     </div>
-  )
+  );
 }

--- a/M8MED/src/components/FormDoctor.tsx
+++ b/M8MED/src/components/FormDoctor.tsx
@@ -14,6 +14,8 @@ export default function FormDoctor({ onFinish, doctor }: Props) {
     nombre: doctor?.nombre ?? '',
     apellido: doctor?.apellido ?? '',
     email: doctor?.email ?? '',
+    password: doctor?.password ?? '',
+    foto: doctor?.foto ?? '',
     telefono: doctor?.telefono ?? '',
     matricula: doctor?.matricula ?? '',
     especialidad: doctor?.especialidad ?? '',
@@ -66,6 +68,22 @@ export default function FormDoctor({ onFinish, doctor }: Props) {
           onChange={handleChange}
           className="input"
           required
+        />
+        <input
+          name="password"
+          type="password"
+          placeholder="Contraseña"
+          value={form.password}
+          onChange={handleChange}
+          className="input"
+          required
+        />
+        <input
+          name="foto"
+          placeholder="URL Foto"
+          value={form.foto}
+          onChange={handleChange}
+          className="input"
         />
         <input
           name="telefono"

--- a/M8MED/src/components/FormDoctor.tsx
+++ b/M8MED/src/components/FormDoctor.tsx
@@ -1,15 +1,15 @@
-import { useState } from 'react'
-import { useM8Store, type Doctor } from '../store/useM8Store'
-import { v4 as uuidv4 } from 'uuid'
+import { useState } from 'react';
+import { useM8Store, type Doctor } from '../store/useM8Store';
+import { v4 as uuidv4 } from 'uuid';
 
 type Props = {
-  onFinish: () => void
-  doctor?: Doctor
-}
+  onFinish: () => void;
+  doctor?: Doctor;
+};
 
 export default function FormDoctor({ onFinish, doctor }: Props) {
-  const agregarDoctor = useM8Store((s) => s.agregarDoctor)
-  const editarDoctor = useM8Store((s) => s.editarDoctor)
+  const agregarDoctor = useM8Store((s) => s.agregarDoctor);
+  const editarDoctor = useM8Store((s) => s.editarDoctor);
   const [form, setForm] = useState({
     nombre: doctor?.nombre ?? '',
     apellido: doctor?.apellido ?? '',
@@ -19,30 +19,33 @@ export default function FormDoctor({ onFinish, doctor }: Props) {
     telefono: doctor?.telefono ?? '',
     matricula: doctor?.matricula ?? '',
     especialidad: doctor?.especialidad ?? '',
-  })
+  });
 
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
   ) => {
-    const { name, value } = e.target
-    setForm({ ...form, [name]: value })
-  }
+    const { name, value } = e.target;
+    setForm({ ...form, [name]: value });
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
+    e.preventDefault();
     if (doctor) {
-      editarDoctor(doctor.id, form)
+      editarDoctor(doctor.id, form);
     } else {
       agregarDoctor({
         ...form,
         id: uuidv4(),
-      })
+      });
     }
-    onFinish()
-  }
+    onFinish();
+  };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4 bg-white p-6 rounded-lg shadow mt-6">
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 bg-white p-6 rounded-lg shadow mt-6"
+    >
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <input
           name="nombre"
@@ -114,5 +117,5 @@ export default function FormDoctor({ onFinish, doctor }: Props) {
         {doctor ? 'Guardar cambios' : 'Guardar médico'}
       </button>
     </form>
-  )
+  );
 }

--- a/M8MED/src/components/FormPaciente.tsx
+++ b/M8MED/src/components/FormPaciente.tsx
@@ -1,19 +1,23 @@
-import { useState } from 'react'
-import { usePacienteStore } from '../store/usePacienteStore'
-import { useM8Store } from '../store/useM8Store'
-import type { Paciente } from '../types/paciente'
-import { v4 as uuidv4 } from 'uuid'
+import { useState } from 'react';
+import { usePacienteStore } from '../store/usePacienteStore';
+import { useM8Store } from '../store/useM8Store';
+import type { Paciente } from '../types/paciente';
+import { v4 as uuidv4 } from 'uuid';
 
 type FormPacienteProps = {
-  onFinish: () => void
-  paciente?: Paciente
-  doctorIdFixed?: string
-}
+  onFinish: () => void;
+  paciente?: Paciente;
+  doctorIdFixed?: string;
+};
 
-export default function FormPaciente({ onFinish, paciente, doctorIdFixed }: FormPacienteProps) {
-  const agregarPaciente = usePacienteStore((state) => state.agregarPaciente)
-  const editarPaciente = usePacienteStore((state) => state.editarPaciente)
-  const doctores = useM8Store((s) => s.doctores)
+export default function FormPaciente({
+  onFinish,
+  paciente,
+  doctorIdFixed,
+}: FormPacienteProps) {
+  const agregarPaciente = usePacienteStore((state) => state.agregarPaciente);
+  const editarPaciente = usePacienteStore((state) => state.editarPaciente);
+  const doctores = useM8Store((s) => s.doctores);
 
   const [form, setForm] = useState<Omit<Paciente, 'id'>>({
     nombre: paciente?.nombre ?? '',
@@ -27,71 +31,140 @@ export default function FormPaciente({ onFinish, paciente, doctorIdFixed }: Form
     fechaNacimiento: paciente?.fechaNacimiento ?? '',
     tratamiento: paciente?.tratamiento ?? '',
     doctorId: doctorIdFixed ?? paciente?.doctorId ?? doctores[0]?.id ?? '',
-  })
+  });
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
-    const { name, value } = e.target
-    setForm({ ...form, [name]: value })
-  }
+  const handleChange = (
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >,
+  ) => {
+    const { name, value } = e.target;
+    setForm({ ...form, [name]: value });
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
+    e.preventDefault();
     if (paciente) {
-      editarPaciente(paciente.id, form)
+      editarPaciente(paciente.id, form);
     } else {
       const nuevoPaciente: Paciente = {
         ...form,
         id: uuidv4(),
-      }
-      agregarPaciente(nuevoPaciente)
+      };
+      agregarPaciente(nuevoPaciente);
     }
-    onFinish()
-  }
+    onFinish();
+  };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4 bg-white p-6 rounded-lg shadow mt-6">
-       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <input
-            name="nombre"
-            placeholder="Nombre"
-            value={form.nombre}
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 bg-white p-6 rounded-lg shadow mt-6"
+    >
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <input
+          name="nombre"
+          placeholder="Nombre"
+          value={form.nombre}
+          onChange={handleChange}
+          className="input"
+          required
+        />
+        <input
+          name="apellido"
+          placeholder="Apellido"
+          value={form.apellido}
+          onChange={handleChange}
+          className="input"
+          required
+        />
+        <input
+          name="dni"
+          placeholder="DNI"
+          value={form.dni}
+          onChange={handleChange}
+          className="input"
+          required
+        />
+        <input
+          name="telefono"
+          placeholder="Teléfono"
+          value={form.telefono}
+          onChange={handleChange}
+          className="input"
+          required
+        />
+        <input
+          name="email"
+          placeholder="Email"
+          type="email"
+          value={form.email}
+          onChange={handleChange}
+          className="input"
+          required
+        />
+        <input
+          name="fechaNacimiento"
+          placeholder="Fecha de nacimiento"
+          type="date"
+          value={form.fechaNacimiento}
+          onChange={handleChange}
+          className="input"
+          required
+        />
+        <select
+          name="genero"
+          value={form.genero}
+          onChange={handleChange}
+          className="input"
+        >
+          <option value="masculino">Masculino</option>
+          <option value="femenino">Femenino</option>
+          <option value="otro">Otro</option>
+        </select>
+        <input
+          name="diagnostico"
+          placeholder="Diagnóstico"
+          value={form.diagnostico}
+          onChange={handleChange}
+          className="input"
+          required
+        />
+        <input
+          name="tratamiento"
+          placeholder="Tratamiento"
+          value={form.tratamiento}
+          onChange={handleChange}
+          className="input"
+          required
+        />
+        {doctorIdFixed ? null : (
+          <select
+            name="doctorId"
+            value={form.doctorId}
             onChange={handleChange}
             className="input"
-            required
-          />
-          <input
-            name="apellido"
-            placeholder="Apellido"
-            value={form.apellido}
-            onChange={handleChange}
-            className="input"
-            required
-          />
-          <input name="dni" placeholder="DNI" value={form.dni} onChange={handleChange} className="input" required />
-          <input name="telefono" placeholder="Teléfono" value={form.telefono} onChange={handleChange} className="input" required />
-          <input name="email" placeholder="Email" type="email" value={form.email} onChange={handleChange} className="input" required />
-          <input name="fechaNacimiento" placeholder="Fecha de nacimiento" type="date" value={form.fechaNacimiento} onChange={handleChange} className="input" required />
-          <select name="genero" value={form.genero} onChange={handleChange} className="input">
-            <option value="masculino">Masculino</option>
-            <option value="femenino">Femenino</option>
-            <option value="otro">Otro</option>
+          >
+            {doctores.map((d) => (
+              <option key={d.id} value={d.id}>
+                {d.nombre} {d.apellido}
+              </option>
+            ))}
           </select>
-          <input name="diagnostico" placeholder="Diagnóstico" value={form.diagnostico} onChange={handleChange} className="input" required />
-          <input name="tratamiento" placeholder="Tratamiento" value={form.tratamiento} onChange={handleChange} className="input" required />
-          {doctorIdFixed ? null : (
-            <select name="doctorId" value={form.doctorId} onChange={handleChange} className="input">
-              {doctores.map((d) => (
-                <option key={d.id} value={d.id}>
-                  {d.nombre} {d.apellido}
-                </option>
-              ))}
-            </select>
-          )}
-        </div>
+        )}
+      </div>
 
-        <textarea name="antecedentes" placeholder="Antecedentes (opcional)" value={form.antecedentes} onChange={e => handleChange(e)} className="input w-full h-24" />
+      <textarea
+        name="antecedentes"
+        placeholder="Antecedentes (opcional)"
+        value={form.antecedentes}
+        onChange={(e) => handleChange(e)}
+        className="input w-full h-24"
+      />
 
-        <button type="submit" className="btn w-full">Guardar paciente</button>
+      <button type="submit" className="btn w-full">
+        Guardar paciente
+      </button>
     </form>
-  )
+  );
 }

--- a/M8MED/src/components/FormPaciente.tsx
+++ b/M8MED/src/components/FormPaciente.tsx
@@ -7,9 +7,10 @@ import { v4 as uuidv4 } from 'uuid'
 type FormPacienteProps = {
   onFinish: () => void
   paciente?: Paciente
+  doctorIdFixed?: string
 }
 
-export default function FormPaciente({ onFinish, paciente }: FormPacienteProps) {
+export default function FormPaciente({ onFinish, paciente, doctorIdFixed }: FormPacienteProps) {
   const agregarPaciente = usePacienteStore((state) => state.agregarPaciente)
   const editarPaciente = usePacienteStore((state) => state.editarPaciente)
   const doctores = useM8Store((s) => s.doctores)
@@ -25,7 +26,7 @@ export default function FormPaciente({ onFinish, paciente }: FormPacienteProps) 
     antecedentes: paciente?.antecedentes ?? '',
     fechaNacimiento: paciente?.fechaNacimiento ?? '',
     tratamiento: paciente?.tratamiento ?? '',
-    doctorId: paciente?.doctorId ?? doctores[0]?.id ?? '',
+    doctorId: doctorIdFixed ?? paciente?.doctorId ?? doctores[0]?.id ?? '',
   })
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
@@ -77,13 +78,15 @@ export default function FormPaciente({ onFinish, paciente }: FormPacienteProps) 
           </select>
           <input name="diagnostico" placeholder="Diagnóstico" value={form.diagnostico} onChange={handleChange} className="input" required />
           <input name="tratamiento" placeholder="Tratamiento" value={form.tratamiento} onChange={handleChange} className="input" required />
-          <select name="doctorId" value={form.doctorId} onChange={handleChange} className="input">
-            {doctores.map((d) => (
-              <option key={d.id} value={d.id}>
-                {d.nombre} {d.apellido}
-              </option>
-            ))}
-          </select>
+          {doctorIdFixed ? null : (
+            <select name="doctorId" value={form.doctorId} onChange={handleChange} className="input">
+              {doctores.map((d) => (
+                <option key={d.id} value={d.id}>
+                  {d.nombre} {d.apellido}
+                </option>
+              ))}
+            </select>
+          )}
         </div>
 
         <textarea name="antecedentes" placeholder="Antecedentes (opcional)" value={form.antecedentes} onChange={e => handleChange(e)} className="input w-full h-24" />

--- a/M8MED/src/components/FormPaciente.tsx
+++ b/M8MED/src/components/FormPaciente.tsx
@@ -4,23 +4,25 @@ import type { Paciente } from '../types/paciente'
 import { v4 as uuidv4 } from 'uuid'
 
 type FormPacienteProps = {
-  onPacienteAgregado: () => void;
+  onFinish: () => void
+  paciente?: Paciente
 }
 
-export default function FormPaciente({ onPacienteAgregado }: FormPacienteProps) {
+export default function FormPaciente({ onFinish, paciente }: FormPacienteProps) {
   const agregarPaciente = usePacienteStore((state) => state.agregarPaciente)
+  const editarPaciente = usePacienteStore((state) => state.editarPaciente)
 
   const [form, setForm] = useState<Omit<Paciente, 'id'>>({
-    nombre: '',
-    apellido: '',
-    dni: '',
-    telefono: '',
-    genero: 'masculino',
-    email: '',
-    diagnostico: '',
-    antecedentes: '',
-    fechaNacimiento: '',
-    tratamiento: ''
+    nombre: paciente?.nombre ?? '',
+    apellido: paciente?.apellido ?? '',
+    dni: paciente?.dni ?? '',
+    telefono: paciente?.telefono ?? '',
+    genero: paciente?.genero ?? 'masculino',
+    email: paciente?.email ?? '',
+    diagnostico: paciente?.diagnostico ?? '',
+    antecedentes: paciente?.antecedentes ?? '',
+    fechaNacimiento: paciente?.fechaNacimiento ?? '',
+    tratamiento: paciente?.tratamiento ?? '',
   })
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
@@ -30,12 +32,16 @@ export default function FormPaciente({ onPacienteAgregado }: FormPacienteProps) 
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    const nuevoPaciente: Paciente = {
-      ...form,
-      id: uuidv4()
+    if (paciente) {
+      editarPaciente(paciente.id, form)
+    } else {
+      const nuevoPaciente: Paciente = {
+        ...form,
+        id: uuidv4(),
+      }
+      agregarPaciente(nuevoPaciente)
     }
-    agregarPaciente(nuevoPaciente)
-    onPacienteAgregado(); // <-- USA EL CALLBACK
+    onFinish()
   }
 
   return (

--- a/M8MED/src/components/FormPaciente.tsx
+++ b/M8MED/src/components/FormPaciente.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { usePacienteStore } from '../store/usePacienteStore'
+import { useM8Store } from '../store/useM8Store'
 import type { Paciente } from '../types/paciente'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -11,6 +12,7 @@ type FormPacienteProps = {
 export default function FormPaciente({ onFinish, paciente }: FormPacienteProps) {
   const agregarPaciente = usePacienteStore((state) => state.agregarPaciente)
   const editarPaciente = usePacienteStore((state) => state.editarPaciente)
+  const doctores = useM8Store((s) => s.doctores)
 
   const [form, setForm] = useState<Omit<Paciente, 'id'>>({
     nombre: paciente?.nombre ?? '',
@@ -23,6 +25,7 @@ export default function FormPaciente({ onFinish, paciente }: FormPacienteProps) 
     antecedentes: paciente?.antecedentes ?? '',
     fechaNacimiento: paciente?.fechaNacimiento ?? '',
     tratamiento: paciente?.tratamiento ?? '',
+    doctorId: paciente?.doctorId ?? doctores[0]?.id ?? '',
   })
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
@@ -74,6 +77,13 @@ export default function FormPaciente({ onFinish, paciente }: FormPacienteProps) 
           </select>
           <input name="diagnostico" placeholder="Diagnóstico" value={form.diagnostico} onChange={handleChange} className="input" required />
           <input name="tratamiento" placeholder="Tratamiento" value={form.tratamiento} onChange={handleChange} className="input" required />
+          <select name="doctorId" value={form.doctorId} onChange={handleChange} className="input">
+            {doctores.map((d) => (
+              <option key={d.id} value={d.id}>
+                {d.nombre} {d.apellido}
+              </option>
+            ))}
+          </select>
         </div>
 
         <textarea name="antecedentes" placeholder="Antecedentes (opcional)" value={form.antecedentes} onChange={e => handleChange(e)} className="input w-full h-24" />

--- a/M8MED/src/components/FormSurgery.tsx
+++ b/M8MED/src/components/FormSurgery.tsx
@@ -1,25 +1,25 @@
-import { useState } from 'react'
-import { v4 as uuidv4 } from 'uuid'
-import { useM8Store, type Surgery } from '../store/useM8Store'
-import { usePacienteStore } from '../store/usePacienteStore'
-import type { Paciente } from '../types/paciente'
+import { useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { useM8Store, type Surgery } from '../store/useM8Store';
+import { usePacienteStore } from '../store/usePacienteStore';
+import type { Paciente } from '../types/paciente';
 
 type Props = {
-  onFinish: () => void
-  surgery?: Surgery
-}
+  onFinish: () => void;
+  surgery?: Surgery;
+};
 
 export default function FormSurgery({ onFinish, surgery }: Props) {
-  const agregarCirugia = useM8Store((s) => s.agregarCirugia)
-  const editarCirugia = useM8Store((s) => s.editarCirugia)
-  const doctores = useM8Store((s) => s.doctores)
+  const agregarCirugia = useM8Store((s) => s.agregarCirugia);
+  const editarCirugia = useM8Store((s) => s.editarCirugia);
+  const doctores = useM8Store((s) => s.doctores);
 
-  const pacientes = usePacienteStore((s) => s.pacientes)
-  const agregarPaciente = usePacienteStore((s) => s.agregarPaciente)
+  const pacientes = usePacienteStore((s) => s.pacientes);
+  const agregarPaciente = usePacienteStore((s) => s.agregarPaciente);
 
-  const [usarExistente, setUsarExistente] = useState(true)
-  const [pacienteId, setPacienteId] = useState('')
-  const [pacienteNuevo, setPacienteNuevo] = useState({ nombre: '', dni: '' })
+  const [usarExistente, setUsarExistente] = useState(true);
+  const [pacienteId, setPacienteId] = useState('');
+  const [pacienteNuevo, setPacienteNuevo] = useState({ nombre: '', dni: '' });
 
   const [form, setForm] = useState({
     fecha: surgery?.fecha ?? '',
@@ -30,30 +30,30 @@ export default function FormSurgery({ onFinish, surgery }: Props) {
     doctorId: surgery?.doctorId ?? '',
     ayudantes: surgery?.ayudantes ?? ([] as string[]),
     imagen: surgery?.imagen ?? '',
-  })
+  });
 
   const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    let paciente: { nombre: string; dni: string }
+    e.preventDefault();
+    let paciente: { nombre: string; dni: string };
     if (surgery) {
-      paciente = surgery.paciente
+      paciente = surgery.paciente;
     } else {
       paciente = usarExistente
-        ? pacientes.find((p) => p.id === pacienteId) ?? {
+        ? (pacientes.find((p) => p.id === pacienteId) ?? {
             nombre: '',
             dni: '',
-          }
-        : pacienteNuevo
+          })
+        : pacienteNuevo;
 
       if (!paciente.nombre || !paciente.dni) {
-        alert('Faltan datos del paciente')
-        return
+        alert('Faltan datos del paciente');
+        return;
       }
 
       if (!usarExistente) {
-        const existe = pacientes.some((p) => p.dni === paciente.dni)
+        const existe = pacientes.some((p) => p.dni === paciente.dni);
         if (!existe) {
-          const [nombre, ...apRest] = paciente.nombre.trim().split(' ')
+          const [nombre, ...apRest] = paciente.nombre.trim().split(' ');
           const nuevoPaciente: Paciente = {
             id: uuidv4(),
             nombre,
@@ -67,22 +67,22 @@ export default function FormSurgery({ onFinish, surgery }: Props) {
             fechaNacimiento: '',
             tratamiento: '',
             doctorId: form.doctorId,
-          }
-          agregarPaciente(nuevoPaciente)
+          };
+          agregarPaciente(nuevoPaciente);
         }
       }
     }
 
     if (surgery) {
-      editarCirugia(surgery.id, { ...form, paciente })
-      alert('Cirugía modificada')
+      editarCirugia(surgery.id, { ...form, paciente });
+      alert('Cirugía modificada');
     } else {
-      agregarCirugia({ ...form, paciente })
-      alert('Cirugía guardada')
+      agregarCirugia({ ...form, paciente });
+      alert('Cirugía guardada');
     }
 
-    onFinish()
-  }
+    onFinish();
+  };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
@@ -231,13 +231,13 @@ export default function FormSurgery({ onFinish, surgery }: Props) {
         type="file"
         accept="image/*"
         onChange={(e) => {
-          const file = e.target.files?.[0]
-          if (!file) return
-          const reader = new FileReader()
+          const file = e.target.files?.[0];
+          if (!file) return;
+          const reader = new FileReader();
           reader.onloadend = () => {
-            setForm({ ...form, imagen: reader.result as string })
-          }
-          reader.readAsDataURL(file)
+            setForm({ ...form, imagen: reader.result as string });
+          };
+          reader.readAsDataURL(file);
         }}
         className="input"
       />
@@ -246,6 +246,5 @@ export default function FormSurgery({ onFinish, surgery }: Props) {
         {surgery ? 'Guardar cambios' : 'Guardar cirugía'}
       </button>
     </form>
-  )
+  );
 }
-

--- a/M8MED/src/components/FormSurgery.tsx
+++ b/M8MED/src/components/FormSurgery.tsx
@@ -66,6 +66,7 @@ export default function FormSurgery({ onFinish, surgery }: Props) {
             antecedentes: '',
             fechaNacimiento: '',
             tratamiento: '',
+            doctorId: form.doctorId,
           }
           agregarPaciente(nuevoPaciente)
         }

--- a/M8MED/src/components/FormTurno.tsx
+++ b/M8MED/src/components/FormTurno.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import { useTurnoStore, type Turno } from '../store/useTurnoStore'
+import { useM8Store } from '../store/useM8Store'
+import { usePacienteStore } from '../store/usePacienteStore'
+
+type Props = {
+  onFinish: () => void
+  turno?: Turno
+  doctorIdFixed?: string
+}
+
+export default function FormTurno({ onFinish, turno, doctorIdFixed }: Props) {
+  const agregarTurno = useTurnoStore((s) => s.agregarTurno)
+  const editarTurno = useTurnoStore((s) => s.editarTurno)
+  const doctores = useM8Store((s) => s.doctores)
+  const pacientesAll = usePacienteStore((s) => s.pacientes)
+
+  const [form, setForm] = useState<Omit<Turno, 'id'>>({
+    doctorId: doctorIdFixed ?? turno?.doctorId ?? doctores[0]?.id ?? '',
+    pacienteId: turno?.pacienteId ?? '',
+    fecha: turno?.fecha ?? '',
+    hora: turno?.hora ?? '',
+  })
+
+  const pacientes = doctorIdFixed
+    ? pacientesAll.filter((p) => p.doctorId === (doctorIdFixed ?? turno?.doctorId))
+    : pacientesAll
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target
+    setForm({ ...form, [name]: value })
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (turno) {
+      editarTurno(turno.id, form)
+    } else {
+      agregarTurno(form)
+    }
+    onFinish()
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {doctorIdFixed ? null : (
+        <select
+          name="doctorId"
+          value={form.doctorId}
+          onChange={handleChange}
+          className="input w-full"
+        >
+          {doctores.map((d) => (
+            <option key={d.id} value={d.id}>
+              {d.nombre} {d.apellido}
+            </option>
+          ))}
+        </select>
+      )}
+      <select
+        name="pacienteId"
+        value={form.pacienteId}
+        onChange={handleChange}
+        className="input w-full"
+        required
+      >
+        <option value="" disabled>
+          Seleccione paciente
+        </option>
+        {pacientes.map((p) => (
+          <option key={p.id} value={p.id}>
+            {p.nombre} {p.apellido}
+          </option>
+        ))}
+      </select>
+      <input
+        type="date"
+        name="fecha"
+        value={form.fecha}
+        onChange={handleChange}
+        className="input w-full"
+        required
+      />
+      <input
+        type="time"
+        name="hora"
+        value={form.hora}
+        onChange={handleChange}
+        className="input w-full"
+        required
+      />
+      <button type="submit" className="btn w-full">
+        Guardar turno
+      </button>
+    </form>
+  )
+}

--- a/M8MED/src/components/FormTurno.tsx
+++ b/M8MED/src/components/FormTurno.tsx
@@ -1,19 +1,19 @@
-import { useState } from 'react'
-import { useTurnoStore, type Turno } from '../store/useTurnoStore'
-import { useM8Store } from '../store/useM8Store'
-import { usePacienteStore } from '../store/usePacienteStore'
+import { useState } from 'react';
+import { useTurnoStore, type Turno } from '../store/useTurnoStore';
+import { useM8Store } from '../store/useM8Store';
+import { usePacienteStore } from '../store/usePacienteStore';
 
 type Props = {
-  onFinish: () => void
-  turno?: Turno
-  doctorIdFixed?: string
-}
+  onFinish: () => void;
+  turno?: Turno;
+  doctorIdFixed?: string;
+};
 
 export default function FormTurno({ onFinish, turno, doctorIdFixed }: Props) {
-  const agregarTurno = useTurnoStore((s) => s.agregarTurno)
-  const editarTurno = useTurnoStore((s) => s.editarTurno)
-  const doctores = useM8Store((s) => s.doctores)
-  const pacientesAll = usePacienteStore((s) => s.pacientes)
+  const agregarTurno = useTurnoStore((s) => s.agregarTurno);
+  const editarTurno = useTurnoStore((s) => s.editarTurno);
+  const doctores = useM8Store((s) => s.doctores);
+  const pacientesAll = usePacienteStore((s) => s.pacientes);
 
   const [form, setForm] = useState<Omit<Turno, 'id'>>({
     doctorId: doctorIdFixed ?? turno?.doctorId ?? doctores[0]?.id ?? '',
@@ -22,30 +22,32 @@ export default function FormTurno({ onFinish, turno, doctorIdFixed }: Props) {
     hora: turno?.hora ?? '',
     tipo: turno?.tipo ?? 'consultorio',
     descripcion: turno?.descripcion ?? '',
-  })
+  });
 
   const pacientes = doctorIdFixed
-    ? pacientesAll.filter((p) => p.doctorId === (doctorIdFixed ?? turno?.doctorId))
-    : pacientesAll
+    ? pacientesAll.filter(
+        (p) => p.doctorId === (doctorIdFixed ?? turno?.doctorId),
+      )
+    : pacientesAll;
 
   const handleChange = (
     e: React.ChangeEvent<
       HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
-    >
+    >,
   ) => {
-    const { name, value } = e.target
-    setForm({ ...form, [name]: value })
-  }
+    const { name, value } = e.target;
+    setForm({ ...form, [name]: value });
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
+    e.preventDefault();
     if (turno) {
-      editarTurno(turno.id, form)
+      editarTurno(turno.id, form);
     } else {
-      agregarTurno(form)
+      agregarTurno(form);
     }
-    onFinish()
-  }
+    onFinish();
+  };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
@@ -116,5 +118,5 @@ export default function FormTurno({ onFinish, turno, doctorIdFixed }: Props) {
         Guardar turno
       </button>
     </form>
-  )
+  );
 }

--- a/M8MED/src/components/FormTurno.tsx
+++ b/M8MED/src/components/FormTurno.tsx
@@ -20,6 +20,8 @@ export default function FormTurno({ onFinish, turno, doctorIdFixed }: Props) {
     pacienteId: turno?.pacienteId ?? '',
     fecha: turno?.fecha ?? '',
     hora: turno?.hora ?? '',
+    tipo: turno?.tipo ?? 'consultorio',
+    descripcion: turno?.descripcion ?? '',
   })
 
   const pacientes = doctorIdFixed
@@ -27,7 +29,9 @@ export default function FormTurno({ onFinish, turno, doctorIdFixed }: Props) {
     : pacientesAll
 
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >
   ) => {
     const { name, value } = e.target
     setForm({ ...form, [name]: value })
@@ -90,6 +94,23 @@ export default function FormTurno({ onFinish, turno, doctorIdFixed }: Props) {
         onChange={handleChange}
         className="input w-full"
         required
+      />
+      <select
+        name="tipo"
+        value={form.tipo}
+        onChange={handleChange}
+        className="input w-full"
+        required
+      >
+        <option value="consultorio">Consultorio</option>
+        <option value="quirurgico">Quirúrgico</option>
+      </select>
+      <textarea
+        name="descripcion"
+        value={form.descripcion}
+        onChange={handleChange}
+        className="input w-full"
+        placeholder="Descripción breve"
       />
       <button type="submit" className="btn w-full">
         Guardar turno

--- a/M8MED/src/components/Modal.tsx
+++ b/M8MED/src/components/Modal.tsx
@@ -1,15 +1,15 @@
-import React from 'react'
+import React from 'react';
 
 export default function Modal({
   isOpen,
   onClose,
   children,
 }: {
-  isOpen: boolean
-  onClose: () => void
-  children: React.ReactNode
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
 }) {
-  if (!isOpen) return null
+  if (!isOpen) return null;
   return (
     <div
       className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50"
@@ -20,12 +20,15 @@ export default function Modal({
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex justify-end">
-          <button onClick={onClose} className="text-red-600 hover:underline mb-2">
+          <button
+            onClick={onClose}
+            className="text-red-600 hover:underline mb-2"
+          >
             Cerrar
           </button>
         </div>
         {children}
       </div>
     </div>
-  )
+  );
 }

--- a/M8MED/src/components/Navbar.tsx
+++ b/M8MED/src/components/Navbar.tsx
@@ -1,14 +1,34 @@
 import { Link, useNavigate } from 'react-router-dom'
-import { useState } from 'react'
+import {
+  Disclosure,
+  DisclosureButton,
+  DisclosurePanel,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuItems,
+} from '@headlessui/react'
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
 import { useUserStore } from '../store/useUserStore'
 
+function classNames(...classes: string[]) {
+  return classes.filter(Boolean).join(' ')
+}
+
 export default function Navbar() {
-  // Recuperamos cada valor por separado para no crear objetos nuevos en cada render
   const user = useUserStore((state) => state.user)
   const logout = useUserStore((state) => state.logout)
   const navigate = useNavigate()
 
-  const [open, setOpen] = useState(false)
+  const navigation = user
+    ? user.rol === 'admin'
+      ? [
+          { name: 'Dashboard', href: '/dashboard-admin' },
+          { name: 'Pacientes', href: '/pacientes' },
+          { name: 'Turnos', href: '/turnos' },
+        ]
+      : [{ name: 'Dashboard', href: '/dashboard-medico' }]
+    : []
 
   const handleLogout = () => {
     logout()
@@ -16,51 +36,137 @@ export default function Navbar() {
   }
 
   return (
-    <nav className="bg-gradient-to-r from-sky-600 to-indigo-600 text-white shadow-md fixed top-0 inset-x-0 z-10">
-      <div className="max-w-7xl mx-auto flex justify-between items-center px-4 py-3">
-        <Link to="/" className="text-xl font-bold">
-          MEDM8
-        </Link>
-        {user && (
-          <div className="flex items-center gap-6 relative">
-            {user.rol === 'admin' && (
-              <Link to="/pacientes" className="hover:underline">
-                Pacientes
-              </Link>
-            )}
-            <button
-              onClick={() => setOpen((o) => !o)}
-              className="flex items-center gap-2 focus:outline-none"
-            >
-              <img
-                src={user.foto || 'https://placehold.co/32'}
-                alt="avatar"
-                className="w-8 h-8 rounded-full object-cover"
-              />
-              <span className="hidden sm:block font-medium">
-                {user.nombre} {user.apellido}
-              </span>
-            </button>
-            {open && (
-              <div className="absolute right-0 top-12 bg-white text-gray-800 rounded shadow-lg w-40">
-                <Link
-                  to="/perfil"
-                  onClick={() => setOpen(false)}
-                  className="block px-4 py-2 hover:bg-gray-100"
-                >
-                  Mi perfil
+    <Disclosure as="nav" className="bg-gray-800 fixed top-0 inset-x-0 z-10">
+      {({ open }) => (
+        <>
+          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+            <div className="flex h-16 items-center justify-between">
+              <div className="flex items-center">
+                <Link to="/" className="shrink-0 text-white font-bold">
+                  MEDM8
                 </Link>
-                <button
-                  onClick={handleLogout}
-                  className="w-full text-left px-4 py-2 hover:bg-gray-100"
+                <div className="hidden md:block">
+                  <div className="ml-10 flex items-baseline space-x-4">
+                    {navigation.map((item) => (
+                      <Link
+                        key={item.name}
+                        to={item.href}
+                        className="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-sm font-medium"
+                      >
+                        {item.name}
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              {user && (
+                <div className="hidden md:block">
+                  <div className="ml-4 flex items-center md:ml-6">
+                    <Menu as="div" className="relative ml-3">
+                      <MenuButton className="relative flex max-w-xs items-center rounded-full bg-gray-800 text-sm focus:outline-none">
+                        <span className="sr-only">Open user menu</span>
+                        <img
+                          src={user.foto || 'https://placehold.co/32'}
+                          alt=""
+                          className="size-8 rounded-full"
+                        />
+                        <span className="ml-2 text-white hidden sm:block">
+                          {user.nombre} {user.apellido}
+                        </span>
+                      </MenuButton>
+                      <MenuItems className="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-none">
+                        <MenuItem>
+                          {({ focus }) => (
+                            <Link
+                              to="/perfil"
+                              className={classNames(
+                                focus ? 'bg-gray-100' : '',
+                                'block px-4 py-2 text-sm text-gray-700'
+                              )}
+                            >
+                              Mi perfil
+                            </Link>
+                          )}
+                        </MenuItem>
+                        <MenuItem>
+                          {({ focus }) => (
+                            <button
+                              onClick={handleLogout}
+                              className={classNames(
+                                focus ? 'bg-gray-100' : '',
+                                'block w-full text-left px-4 py-2 text-sm text-gray-700'
+                              )}
+                            >
+                              Cerrar sesión
+                            </button>
+                          )}
+                        </MenuItem>
+                      </MenuItems>
+                    </Menu>
+                  </div>
+                </div>
+              )}
+              <div className="-mr-2 flex md:hidden">
+                <DisclosureButton className="group inline-flex items-center justify-center rounded-md bg-gray-800 p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800">
+                  <span className="sr-only">Open main menu</span>
+                  <Bars3Icon className={classNames(open ? 'hidden' : 'block', 'size-6')} aria-hidden="true" />
+                  <XMarkIcon className={classNames(open ? 'block' : 'hidden', 'size-6')} aria-hidden="true" />
+                </DisclosureButton>
+              </div>
+            </div>
+          </div>
+
+          <DisclosurePanel className="md:hidden">
+            <div className="space-y-1 px-2 pb-3 pt-2 sm:px-3">
+              {navigation.map((item) => (
+                <DisclosureButton
+                  key={item.name}
+                  as={Link}
+                  to={item.href}
+                  className="block rounded-md px-3 py-2 text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white"
                 >
-                  Cerrar sesión
-                </button>
+                  {item.name}
+                </DisclosureButton>
+              ))}
+            </div>
+            {user && (
+              <div className="border-t border-gray-700 pb-3 pt-4">
+                <div className="flex items-center px-5">
+                  <div className="shrink-0">
+                    <img
+                      src={user.foto || 'https://placehold.co/40'}
+                      alt=""
+                      className="size-10 rounded-full"
+                    />
+                  </div>
+                  <div className="ml-3">
+                    <div className="text-base font-medium text-white">
+                      {user.nombre} {user.apellido}
+                    </div>
+                    <div className="text-sm font-medium text-gray-400">{user.email}</div>
+                  </div>
+                </div>
+                <div className="mt-3 space-y-1 px-2">
+                  <DisclosureButton
+                    as={Link}
+                    to="/perfil"
+                    className="block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-gray-700 hover:text-white"
+                  >
+                    Mi perfil
+                  </DisclosureButton>
+                  <DisclosureButton
+                    as="button"
+                    className="block w-full text-left rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-gray-700 hover:text-white"
+                    onClick={handleLogout}
+                  >
+                    Cerrar sesión
+                  </DisclosureButton>
+                </div>
               </div>
             )}
-          </div>
-        )}
-      </div>
-    </nav>
+          </DisclosurePanel>
+        </>
+      )}
+    </Disclosure>
   )
 }

--- a/M8MED/src/components/Navbar.tsx
+++ b/M8MED/src/components/Navbar.tsx
@@ -40,9 +40,10 @@ export default function Navbar() {
   }
 
   return (
-    <Disclosure as="nav" className="bg-gray-800 fixed top-0 inset-x-0 z-10">
-      {({ open }) => (
-        <>
+    <>
+      <Disclosure as="nav" className="bg-gray-800 fixed top-0 inset-x-0 z-10">
+        {({ open }) => (
+          <>
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             <div className="flex h-16 items-center justify-between">
               <div className="flex items-center">
@@ -171,6 +172,8 @@ export default function Navbar() {
           </DisclosurePanel>
         </>
       )}
-    </Disclosure>
+      </Disclosure>
+      <div className="h-16" />
+    </>
   )
 }

--- a/M8MED/src/components/Navbar.tsx
+++ b/M8MED/src/components/Navbar.tsx
@@ -1,4 +1,5 @@
 import { Link, useNavigate } from 'react-router-dom'
+import { useState } from 'react'
 import { useUserStore } from '../store/useUserStore'
 
 export default function Navbar() {
@@ -6,6 +7,8 @@ export default function Navbar() {
   const user = useUserStore((state) => state.user)
   const logout = useUserStore((state) => state.logout)
   const navigate = useNavigate()
+
+  const [open, setOpen] = useState(false)
 
   const handleLogout = () => {
     logout()
@@ -19,22 +22,42 @@ export default function Navbar() {
           MEDM8
         </Link>
         {user && (
-          <div className="flex items-center gap-6">
-            <span className="hidden sm:block">
-              {user.email} (
-              <span className="font-medium capitalize">{user.rol}</span>)
-            </span>
+          <div className="flex items-center gap-6 relative">
             {user.rol === 'admin' && (
               <Link to="/pacientes" className="hover:underline">
                 Pacientes
               </Link>
             )}
             <button
-              onClick={handleLogout}
-              className="bg-white text-sky-700 font-medium px-4 py-2 rounded-md shadow hover:bg-gray-100 text-sm"
+              onClick={() => setOpen((o) => !o)}
+              className="flex items-center gap-2 focus:outline-none"
             >
-              Cerrar Sesión
+              <img
+                src={user.foto || 'https://placehold.co/32'}
+                alt="avatar"
+                className="w-8 h-8 rounded-full object-cover"
+              />
+              <span className="hidden sm:block font-medium">
+                {user.nombre} {user.apellido}
+              </span>
             </button>
+            {open && (
+              <div className="absolute right-0 top-12 bg-white text-gray-800 rounded shadow-lg w-40">
+                <Link
+                  to="/perfil"
+                  onClick={() => setOpen(false)}
+                  className="block px-4 py-2 hover:bg-gray-100"
+                >
+                  Mi perfil
+                </Link>
+                <button
+                  onClick={handleLogout}
+                  className="w-full text-left px-4 py-2 hover:bg-gray-100"
+                >
+                  Cerrar sesión
+                </button>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/M8MED/src/components/Navbar.tsx
+++ b/M8MED/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom';
 import {
   Disclosure,
   DisclosureButton,
@@ -7,18 +7,18 @@ import {
   MenuButton,
   MenuItem,
   MenuItems,
-} from '@headlessui/react'
-import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
-import { useUserStore } from '../store/useUserStore'
+} from '@headlessui/react';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
+import { useUserStore } from '../store/useUserStore';
 
 function classNames(...classes: string[]) {
-  return classes.filter(Boolean).join(' ')
+  return classes.filter(Boolean).join(' ');
 }
 
 export default function Navbar() {
-  const user = useUserStore((state) => state.user)
-  const logout = useUserStore((state) => state.logout)
-  const navigate = useNavigate()
+  const user = useUserStore((state) => state.user);
+  const logout = useUserStore((state) => state.logout);
+  const navigate = useNavigate();
 
   const navigation = user
     ? user.rol === 'admin'
@@ -32,148 +32,162 @@ export default function Navbar() {
           { name: 'General', href: '/resumen/detalle' },
         ]
       : [{ name: 'Dashboard', href: '/dashboard-medico' }]
-    : []
+    : [];
 
   const handleLogout = () => {
-    logout()
-    navigate('/')
-  }
+    logout();
+    navigate('/');
+  };
 
   return (
     <>
       <Disclosure as="nav" className="bg-gray-800 fixed top-0 inset-x-0 z-10">
         {({ open }) => (
           <>
-          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-            <div className="flex h-16 items-center justify-between">
-              <div className="flex items-center">
-                <Link to="/" className="shrink-0 text-white font-bold">
-                  MEDM8
-                </Link>
-                <div className="hidden md:block">
-                  <div className="ml-10 flex items-baseline space-x-4">
-                    {navigation.map((item) => (
-                      <Link
-                        key={item.name}
-                        to={item.href}
-                        className="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-sm font-medium"
-                      >
-                        {item.name}
-                      </Link>
-                    ))}
+            <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+              <div className="flex h-16 items-center justify-between">
+                <div className="flex items-center">
+                  <Link to="/" className="shrink-0 text-white font-bold">
+                    MEDM8
+                  </Link>
+                  <div className="hidden md:block">
+                    <div className="ml-10 flex items-baseline space-x-4">
+                      {navigation.map((item) => (
+                        <Link
+                          key={item.name}
+                          to={item.href}
+                          className="text-gray-300 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-sm font-medium"
+                        >
+                          {item.name}
+                        </Link>
+                      ))}
+                    </div>
                   </div>
                 </div>
+                {user && (
+                  <div className="hidden md:block">
+                    <div className="ml-4 flex items-center md:ml-6">
+                      <Menu as="div" className="relative ml-3">
+                        <MenuButton className="relative flex max-w-xs items-center rounded-full bg-gray-800 text-sm focus:outline-none">
+                          <span className="sr-only">Open user menu</span>
+                          <img
+                            src={user.foto || 'https://placehold.co/32'}
+                            alt=""
+                            className="size-8 rounded-full"
+                          />
+                          <span className="ml-2 text-white hidden sm:block">
+                            {user.nombre} {user.apellido}
+                          </span>
+                        </MenuButton>
+                        <MenuItems className="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-none">
+                          <MenuItem>
+                            {({ focus }) => (
+                              <Link
+                                to="/perfil"
+                                className={classNames(
+                                  focus ? 'bg-gray-100' : '',
+                                  'block px-4 py-2 text-sm text-gray-700',
+                                )}
+                              >
+                                Mi perfil
+                              </Link>
+                            )}
+                          </MenuItem>
+                          <MenuItem>
+                            {({ focus }) => (
+                              <button
+                                onClick={handleLogout}
+                                className={classNames(
+                                  focus ? 'bg-gray-100' : '',
+                                  'block w-full text-left px-4 py-2 text-sm text-gray-700',
+                                )}
+                              >
+                                Cerrar sesión
+                              </button>
+                            )}
+                          </MenuItem>
+                        </MenuItems>
+                      </Menu>
+                    </div>
+                  </div>
+                )}
+                <div className="-mr-2 flex md:hidden">
+                  <DisclosureButton className="group inline-flex items-center justify-center rounded-md bg-gray-800 p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800">
+                    <span className="sr-only">Open main menu</span>
+                    <Bars3Icon
+                      className={classNames(
+                        open ? 'hidden' : 'block',
+                        'size-6',
+                      )}
+                      aria-hidden="true"
+                    />
+                    <XMarkIcon
+                      className={classNames(
+                        open ? 'block' : 'hidden',
+                        'size-6',
+                      )}
+                      aria-hidden="true"
+                    />
+                  </DisclosureButton>
+                </div>
+              </div>
+            </div>
+
+            <DisclosurePanel className="md:hidden">
+              <div className="space-y-1 px-2 pb-3 pt-2 sm:px-3">
+                {navigation.map((item) => (
+                  <DisclosureButton
+                    key={item.name}
+                    as={Link}
+                    to={item.href}
+                    className="block rounded-md px-3 py-2 text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white"
+                  >
+                    {item.name}
+                  </DisclosureButton>
+                ))}
               </div>
               {user && (
-                <div className="hidden md:block">
-                  <div className="ml-4 flex items-center md:ml-6">
-                    <Menu as="div" className="relative ml-3">
-                      <MenuButton className="relative flex max-w-xs items-center rounded-full bg-gray-800 text-sm focus:outline-none">
-                        <span className="sr-only">Open user menu</span>
-                        <img
-                          src={user.foto || 'https://placehold.co/32'}
-                          alt=""
-                          className="size-8 rounded-full"
-                        />
-                        <span className="ml-2 text-white hidden sm:block">
-                          {user.nombre} {user.apellido}
-                        </span>
-                      </MenuButton>
-                      <MenuItems className="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-none">
-                        <MenuItem>
-                          {({ focus }) => (
-                            <Link
-                              to="/perfil"
-                              className={classNames(
-                                focus ? 'bg-gray-100' : '',
-                                'block px-4 py-2 text-sm text-gray-700'
-                              )}
-                            >
-                              Mi perfil
-                            </Link>
-                          )}
-                        </MenuItem>
-                        <MenuItem>
-                          {({ focus }) => (
-                            <button
-                              onClick={handleLogout}
-                              className={classNames(
-                                focus ? 'bg-gray-100' : '',
-                                'block w-full text-left px-4 py-2 text-sm text-gray-700'
-                              )}
-                            >
-                              Cerrar sesión
-                            </button>
-                          )}
-                        </MenuItem>
-                      </MenuItems>
-                    </Menu>
+                <div className="border-t border-gray-700 pb-3 pt-4">
+                  <div className="flex items-center px-5">
+                    <div className="shrink-0">
+                      <img
+                        src={user.foto || 'https://placehold.co/40'}
+                        alt=""
+                        className="size-10 rounded-full"
+                      />
+                    </div>
+                    <div className="ml-3">
+                      <div className="text-base font-medium text-white">
+                        {user.nombre} {user.apellido}
+                      </div>
+                      <div className="text-sm font-medium text-gray-400">
+                        {user.email}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="mt-3 space-y-1 px-2">
+                    <DisclosureButton
+                      as={Link}
+                      to="/perfil"
+                      className="block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-gray-700 hover:text-white"
+                    >
+                      Mi perfil
+                    </DisclosureButton>
+                    <DisclosureButton
+                      as="button"
+                      className="block w-full text-left rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-gray-700 hover:text-white"
+                      onClick={handleLogout}
+                    >
+                      Cerrar sesión
+                    </DisclosureButton>
                   </div>
                 </div>
               )}
-              <div className="-mr-2 flex md:hidden">
-                <DisclosureButton className="group inline-flex items-center justify-center rounded-md bg-gray-800 p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800">
-                  <span className="sr-only">Open main menu</span>
-                  <Bars3Icon className={classNames(open ? 'hidden' : 'block', 'size-6')} aria-hidden="true" />
-                  <XMarkIcon className={classNames(open ? 'block' : 'hidden', 'size-6')} aria-hidden="true" />
-                </DisclosureButton>
-              </div>
-            </div>
-          </div>
-
-          <DisclosurePanel className="md:hidden">
-            <div className="space-y-1 px-2 pb-3 pt-2 sm:px-3">
-              {navigation.map((item) => (
-                <DisclosureButton
-                  key={item.name}
-                  as={Link}
-                  to={item.href}
-                  className="block rounded-md px-3 py-2 text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white"
-                >
-                  {item.name}
-                </DisclosureButton>
-              ))}
-            </div>
-            {user && (
-              <div className="border-t border-gray-700 pb-3 pt-4">
-                <div className="flex items-center px-5">
-                  <div className="shrink-0">
-                    <img
-                      src={user.foto || 'https://placehold.co/40'}
-                      alt=""
-                      className="size-10 rounded-full"
-                    />
-                  </div>
-                  <div className="ml-3">
-                    <div className="text-base font-medium text-white">
-                      {user.nombre} {user.apellido}
-                    </div>
-                    <div className="text-sm font-medium text-gray-400">{user.email}</div>
-                  </div>
-                </div>
-                <div className="mt-3 space-y-1 px-2">
-                  <DisclosureButton
-                    as={Link}
-                    to="/perfil"
-                    className="block rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-gray-700 hover:text-white"
-                  >
-                    Mi perfil
-                  </DisclosureButton>
-                  <DisclosureButton
-                    as="button"
-                    className="block w-full text-left rounded-md px-3 py-2 text-base font-medium text-gray-400 hover:bg-gray-700 hover:text-white"
-                    onClick={handleLogout}
-                  >
-                    Cerrar sesión
-                  </DisclosureButton>
-                </div>
-              </div>
-            )}
-          </DisclosurePanel>
-        </>
-      )}
+            </DisclosurePanel>
+          </>
+        )}
       </Disclosure>
       <div className="h-16" />
     </>
-  )
+  );
 }

--- a/M8MED/src/components/Navbar.tsx
+++ b/M8MED/src/components/Navbar.tsx
@@ -26,6 +26,10 @@ export default function Navbar() {
           { name: 'Dashboard', href: '/dashboard-admin' },
           { name: 'Pacientes', href: '/pacientes' },
           { name: 'Turnos', href: '/turnos' },
+          { name: 'Nuevo médico', href: '/agregar-medico' },
+          { name: 'Complejidad', href: '/complejidad' },
+          { name: 'Resumen', href: '/resumen' },
+          { name: 'General', href: '/resumen/detalle' },
         ]
       : [{ name: 'Dashboard', href: '/dashboard-medico' }]
     : []

--- a/M8MED/src/index.css
+++ b/M8MED/src/index.css
@@ -21,4 +21,6 @@ body {
   @apply bg-gray-100 text-gray-900 font-sans;
 }
 
-html { scroll-behavior: smooth; }
+html {
+  scroll-behavior: smooth;
+}

--- a/M8MED/src/lib/date.ts
+++ b/M8MED/src/lib/date.ts
@@ -11,9 +11,9 @@ export const meses = [
   { value: 10, label: 'Octubre' },
   { value: 11, label: 'Noviembre' },
   { value: 12, label: 'Diciembre' },
-]
+];
 
 export function ultimosAnios(cantidad = 5): number[] {
-  const actual = new Date().getFullYear()
-  return Array.from({ length: cantidad }, (_, i) => actual - i)
+  const actual = new Date().getFullYear();
+  return Array.from({ length: cantidad }, (_, i) => actual - i);
 }

--- a/M8MED/src/main.tsx
+++ b/M8MED/src/main.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
-import './index.css'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
-)
+  </React.StrictMode>,
+);

--- a/M8MED/src/pages/AgregarDoctor.tsx
+++ b/M8MED/src/pages/AgregarDoctor.tsx
@@ -1,26 +1,31 @@
-import { useNavigate } from 'react-router-dom'
-import Navbar from '../components/Navbar'
-import FormDoctor from '../components/FormDoctor'
+import { useNavigate } from 'react-router-dom';
+import Navbar from '../components/Navbar';
+import FormDoctor from '../components/FormDoctor';
 
 export default function AgregarDoctor() {
-  const navigate = useNavigate()
+  const navigate = useNavigate();
 
   const handleFinish = () => {
-    navigate('/dashboard-admin')
-  }
+    navigate('/dashboard-admin');
+  };
 
   return (
     <>
       <Navbar />
       <header className="bg-white shadow">
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-          <h1 className="text-3xl font-bold tracking-tight text-gray-900">Agregar Médico</h1>
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+            Agregar Médico
+          </h1>
         </div>
       </header>
       <main>
         <div className="mx-auto max-w-2xl px-4 py-6 sm:px-6 lg:px-8">
           <div className="flex justify-end mb-4">
-            <button onClick={() => navigate('/dashboard-admin')} className="text-blue-600 hover:underline">
+            <button
+              onClick={() => navigate('/dashboard-admin')}
+              className="text-blue-600 hover:underline"
+            >
               ← Volver
             </button>
           </div>
@@ -28,6 +33,5 @@ export default function AgregarDoctor() {
         </div>
       </main>
     </>
-  )
+  );
 }
-

--- a/M8MED/src/pages/AgregarDoctor.tsx
+++ b/M8MED/src/pages/AgregarDoctor.tsx
@@ -1,0 +1,33 @@
+import { useNavigate } from 'react-router-dom'
+import Navbar from '../components/Navbar'
+import FormDoctor from '../components/FormDoctor'
+
+export default function AgregarDoctor() {
+  const navigate = useNavigate()
+
+  const handleFinish = () => {
+    navigate('/dashboard-admin')
+  }
+
+  return (
+    <>
+      <Navbar />
+      <header className="bg-white shadow">
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">Agregar Médico</h1>
+        </div>
+      </header>
+      <main>
+        <div className="mx-auto max-w-2xl px-4 py-6 sm:px-6 lg:px-8">
+          <div className="flex justify-end mb-4">
+            <button onClick={() => navigate('/dashboard-admin')} className="text-blue-600 hover:underline">
+              ← Volver
+            </button>
+          </div>
+          <FormDoctor onFinish={handleFinish} />
+        </div>
+      </main>
+    </>
+  )
+}
+

--- a/M8MED/src/pages/AgregarPaciente.tsx
+++ b/M8MED/src/pages/AgregarPaciente.tsx
@@ -12,15 +12,21 @@ export default function AgregarPaciente() {
   return (
     <>
       <Navbar />
-      <div className="max-w-2xl mx-auto p-6">
-        <div className="flex justify-between items-center mb-4">
-            <h1 className="text-2xl font-bold">Agregar Paciente</h1>
-            <button onClick={() => navigate('/pacientes')} className="text-blue-600 hover:underline">
-                ← Volver
-            </button>
+      <header className="bg-white shadow">
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">Agregar Paciente</h1>
         </div>
-        <FormPaciente onFinish={handlePacienteGuardado} />
-      </div>
+      </header>
+      <main>
+        <div className="mx-auto max-w-2xl px-4 py-6 sm:px-6 lg:px-8">
+          <div className="flex justify-end mb-4">
+            <button onClick={() => navigate('/pacientes')} className="text-blue-600 hover:underline">
+              ← Volver
+            </button>
+          </div>
+          <FormPaciente onFinish={handlePacienteGuardado} />
+        </div>
+      </main>
     </>
   )
 }

--- a/M8MED/src/pages/AgregarPaciente.tsx
+++ b/M8MED/src/pages/AgregarPaciente.tsx
@@ -19,7 +19,7 @@ export default function AgregarPaciente() {
                 ← Volver
             </button>
         </div>
-        <FormPaciente onPacienteAgregado={handlePacienteGuardado} />
+        <FormPaciente onFinish={handlePacienteGuardado} />
       </div>
     </>
   )

--- a/M8MED/src/pages/AgregarPaciente.tsx
+++ b/M8MED/src/pages/AgregarPaciente.tsx
@@ -1,26 +1,31 @@
-import { useNavigate } from 'react-router-dom'
-import Navbar from '../components/Navbar'
-import FormPaciente from '../components/FormPaciente' // <-- REUTILIZA EL COMPONENTE
+import { useNavigate } from 'react-router-dom';
+import Navbar from '../components/Navbar';
+import FormPaciente from '../components/FormPaciente'; // <-- REUTILIZA EL COMPONENTE
 
 export default function AgregarPaciente() {
-  const navigate = useNavigate()
+  const navigate = useNavigate();
 
   const handlePacienteGuardado = () => {
-    navigate('/pacientes') // Navega a la lista de pacientes
-  }
+    navigate('/pacientes'); // Navega a la lista de pacientes
+  };
 
   return (
     <>
       <Navbar />
       <header className="bg-white shadow">
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-          <h1 className="text-3xl font-bold tracking-tight text-gray-900">Agregar Paciente</h1>
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+            Agregar Paciente
+          </h1>
         </div>
       </header>
       <main>
         <div className="mx-auto max-w-2xl px-4 py-6 sm:px-6 lg:px-8">
           <div className="flex justify-end mb-4">
-            <button onClick={() => navigate('/pacientes')} className="text-blue-600 hover:underline">
+            <button
+              onClick={() => navigate('/pacientes')}
+              className="text-blue-600 hover:underline"
+            >
               ← Volver
             </button>
           </div>
@@ -28,5 +33,5 @@ export default function AgregarPaciente() {
         </div>
       </main>
     </>
-  )
+  );
 }

--- a/M8MED/src/pages/DashboardAdmin.tsx
+++ b/M8MED/src/pages/DashboardAdmin.tsx
@@ -43,9 +43,13 @@ export default function DashboardAdmin() {
   return (
     <>
       <Navbar />
-      <div className="pt-20 min-h-screen bg-gradient-to-br from-sky-50 to-indigo-100">
-        <div className="max-w-6xl mx-auto p-6">
-          <h1 className="text-3xl font-semibold mb-6">Panel de Admin</h1>
+      <header className="bg-white shadow">
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">Panel de Admin</h1>
+        </div>
+      </header>
+      <main>
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8 bg-gradient-to-br from-sky-50 to-indigo-100 min-h-screen">
           <div className="flex flex-wrap gap-4 mb-8">
           <Link to="/pacientes" className="btn">
             Ver pacientes
@@ -129,11 +133,11 @@ export default function DashboardAdmin() {
             </>
           )}
 
-          {pacientes.length > 0 && (
-            <>
-              <h2 className="text-2xl font-semibold mt-10 mb-4">Pacientes</h2>
-              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-                {pacientes.map((p) => (
+        {pacientes.length > 0 && (
+          <>
+            <h2 className="text-2xl font-semibold mt-10 mb-4">Pacientes</h2>
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {pacientes.map((p) => (
                   <div
                     key={p.id}
                     className="card hover:shadow-md transition-shadow"
@@ -155,7 +159,7 @@ export default function DashboardAdmin() {
             </>
           )}
         </div>
-      </div>
+      </main>
 
       {/* Modales */}
       <Modal isOpen={showComplexity} onClose={() => setShowComplexity(false)}>

--- a/M8MED/src/pages/DashboardAdmin.tsx
+++ b/M8MED/src/pages/DashboardAdmin.tsx
@@ -1,54 +1,58 @@
-import { useState } from 'react'
-import Navbar from '../components/Navbar'
-import { useM8Store } from '../store/useM8Store'
-import DoctorDetail from './DoctorDetail'
-import PatientDetail from './PatientDetail'
-import FormDoctor from '../components/FormDoctor'
-import { usePacienteStore } from '../store/usePacienteStore'
-import Modal from '../components/Modal'
+import { useState } from 'react';
+import Navbar from '../components/Navbar';
+import { useM8Store } from '../store/useM8Store';
+import DoctorDetail from './DoctorDetail';
+import PatientDetail from './PatientDetail';
+import FormDoctor from '../components/FormDoctor';
+import { usePacienteStore } from '../store/usePacienteStore';
+import Modal from '../components/Modal';
 
 export default function DashboardAdmin() {
-  const doctores = useM8Store((state) => state.doctores)
-  const cirugias = useM8Store((state) => state.cirugias)
-  const pacientes = usePacienteStore((s) => s.pacientes)
-  const cambiarEstadoDoctor = useM8Store((s) => s.cambiarEstadoDoctor)
-  const doctoresActivos = doctores.filter((d) => d.activo)
-  const doctoresSuspendidos = doctores.filter((d) => !d.activo)
+  const doctores = useM8Store((state) => state.doctores);
+  const cirugias = useM8Store((state) => state.cirugias);
+  const pacientes = usePacienteStore((s) => s.pacientes);
+  const cambiarEstadoDoctor = useM8Store((s) => s.cambiarEstadoDoctor);
+  const doctoresActivos = doctores.filter((d) => d.activo);
+  const doctoresSuspendidos = doctores.filter((d) => !d.activo);
 
   // Estados para abrir/cerrar modales
-  const [detailDoctorId, setDetailDoctorId] = useState<string | null>(null)
-  const [editDoctorId, setEditDoctorId] = useState<string | null>(null)
-  const [detailPatientId, setDetailPatientId] = useState<string | null>(null)
+  const [detailDoctorId, setDetailDoctorId] = useState<string | null>(null);
+  const [editDoctorId, setEditDoctorId] = useState<string | null>(null);
+  const [detailPatientId, setDetailPatientId] = useState<string | null>(null);
 
   const contarParticipacionesDelMes = (doctorId: string) => {
-    const ahora = new Date()
-    const mesActual = ahora.getMonth()
-    const anioActual = ahora.getFullYear()
+    const ahora = new Date();
+    const mesActual = ahora.getMonth();
+    const anioActual = ahora.getFullYear();
     return cirugias.filter((c) => {
-      const fecha = new Date(`${c.fecha}T${c.hora}`)
+      const fecha = new Date(`${c.fecha}T${c.hora}`);
       return (
         (c.doctorId === doctorId || c.ayudantes.includes(doctorId)) &&
         fecha.getFullYear() === anioActual &&
         fecha.getMonth() === mesActual
-      )
-    }).length
-  }
+      );
+    }).length;
+  };
 
   return (
     <>
       <Navbar />
       <header className="bg-white shadow">
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-          <h1 className="text-3xl font-bold tracking-tight text-gray-900">Panel de Admin</h1>
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+            Panel de Admin
+          </h1>
         </div>
       </header>
       <main>
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8 bg-gradient-to-br from-sky-50 to-indigo-100 min-h-screen">
-
           <h2 className="text-2xl font-semibold mb-4">Médicos activos</h2>
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {doctoresActivos.map((doc) => (
-              <div key={doc.id} className="card hover:shadow-md transition-shadow">
+              <div
+                key={doc.id}
+                className="card hover:shadow-md transition-shadow"
+              >
                 <h3 className="text-lg font-semibold text-slate-800">
                   {doc.nombre} {doc.apellido}
                 </h3>
@@ -86,10 +90,15 @@ export default function DashboardAdmin() {
 
           {doctoresSuspendidos.length > 0 && (
             <>
-              <h2 className="text-2xl font-semibold mt-10 mb-4">Médicos suspendidos</h2>
+              <h2 className="text-2xl font-semibold mt-10 mb-4">
+                Médicos suspendidos
+              </h2>
               <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
                 {doctoresSuspendidos.map((doc) => (
-                  <div key={doc.id} className="card hover:shadow-md transition-shadow">
+                  <div
+                    key={doc.id}
+                    className="card hover:shadow-md transition-shadow"
+                  >
                     <h3 className="text-lg font-semibold text-slate-800">
                       {doc.nombre} {doc.apellido}
                     </h3>
@@ -109,11 +118,11 @@ export default function DashboardAdmin() {
             </>
           )}
 
-        {pacientes.length > 0 && (
-          <>
-            <h2 className="text-2xl font-semibold mt-10 mb-4">Pacientes</h2>
-            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-              {pacientes.map((p) => (
+          {pacientes.length > 0 && (
+            <>
+              <h2 className="text-2xl font-semibold mt-10 mb-4">Pacientes</h2>
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                {pacientes.map((p) => (
                   <div
                     key={p.id}
                     className="card hover:shadow-md transition-shadow"
@@ -138,11 +147,17 @@ export default function DashboardAdmin() {
       </main>
 
       {/* Modales */}
-      <Modal isOpen={detailDoctorId !== null} onClose={() => setDetailDoctorId(null)}>
+      <Modal
+        isOpen={detailDoctorId !== null}
+        onClose={() => setDetailDoctorId(null)}
+      >
         {detailDoctorId && <DoctorDetail doctorId={detailDoctorId} />}
       </Modal>
 
-      <Modal isOpen={editDoctorId !== null} onClose={() => setEditDoctorId(null)}>
+      <Modal
+        isOpen={editDoctorId !== null}
+        onClose={() => setEditDoctorId(null)}
+      >
         {editDoctorId && (
           <FormDoctor
             doctor={doctores.find((d) => d.id === editDoctorId)}
@@ -151,11 +166,14 @@ export default function DashboardAdmin() {
         )}
       </Modal>
 
-      <Modal isOpen={detailPatientId !== null} onClose={() => setDetailPatientId(null)}>
+      <Modal
+        isOpen={detailPatientId !== null}
+        onClose={() => setDetailPatientId(null)}
+      >
         {detailPatientId && <PatientDetail pacienteId={detailPatientId} />}
       </Modal>
     </>
-  )
+  );
 }
 
 /**

--- a/M8MED/src/pages/DashboardAdmin.tsx
+++ b/M8MED/src/pages/DashboardAdmin.tsx
@@ -47,12 +47,13 @@ export default function DashboardAdmin() {
         <div className="max-w-6xl mx-auto p-6">
           <h1 className="text-3xl font-semibold mb-6">Panel de Admin</h1>
           <div className="flex flex-wrap gap-4 mb-8">
-            <Link to="/pacientes" className="btn">
-              Ver pacientes
-            </Link>
-            <button onClick={() => setShowAddDoctor(true)} className="btn">
-              Agregar médico
-            </button>
+          <Link to="/pacientes" className="btn">
+            Ver pacientes
+          </Link>
+          <Link to="/turnos" className="btn">Gestionar turnos</Link>
+          <button onClick={() => setShowAddDoctor(true)} className="btn">
+            Agregar médico
+          </button>
             <button onClick={() => setShowComplexity(true)} className="btn">
               Gestionar complejidad
             </button>

--- a/M8MED/src/pages/DashboardAdmin.tsx
+++ b/M8MED/src/pages/DashboardAdmin.tsx
@@ -1,9 +1,6 @@
 import { useState } from 'react'
-import { Link } from 'react-router-dom'
 import Navbar from '../components/Navbar'
 import { useM8Store } from '../store/useM8Store'
-import EditComplexity from './EditComplexity'
-import Summary from './Summary'
 import DoctorDetail from './DoctorDetail'
 import PatientDetail from './PatientDetail'
 import FormDoctor from '../components/FormDoctor'
@@ -19,9 +16,6 @@ export default function DashboardAdmin() {
   const doctoresSuspendidos = doctores.filter((d) => !d.activo)
 
   // Estados para abrir/cerrar modales
-  const [showComplexity, setShowComplexity] = useState(false)
-  const [showSummary, setShowSummary] = useState(false)
-  const [showAddDoctor, setShowAddDoctor] = useState(false)
   const [detailDoctorId, setDetailDoctorId] = useState<string | null>(null)
   const [editDoctorId, setEditDoctorId] = useState<string | null>(null)
   const [detailPatientId, setDetailPatientId] = useState<string | null>(null)
@@ -50,24 +44,6 @@ export default function DashboardAdmin() {
       </header>
       <main>
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8 bg-gradient-to-br from-sky-50 to-indigo-100 min-h-screen">
-          <div className="flex flex-wrap gap-4 mb-8">
-          <Link to="/pacientes" className="btn">
-            Ver pacientes
-          </Link>
-          <Link to="/turnos" className="btn">Gestionar turnos</Link>
-          <button onClick={() => setShowAddDoctor(true)} className="btn">
-            Agregar médico
-          </button>
-            <button onClick={() => setShowComplexity(true)} className="btn">
-              Gestionar complejidad
-            </button>
-            <button onClick={() => setShowSummary(true)} className="btn">
-              Resumen mensual
-            </button>
-            <Link to="/resumen/detalle" className="btn">
-              Resumen general
-            </Link>
-          </div>
 
           <h2 className="text-2xl font-semibold mb-4">Médicos activos</h2>
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
@@ -162,21 +138,8 @@ export default function DashboardAdmin() {
       </main>
 
       {/* Modales */}
-      <Modal isOpen={showComplexity} onClose={() => setShowComplexity(false)}>
-        <EditComplexity />
-      </Modal>
-
-      <Modal isOpen={showSummary} onClose={() => setShowSummary(false)}>
-        <Summary />
-      </Modal>
-
-
       <Modal isOpen={detailDoctorId !== null} onClose={() => setDetailDoctorId(null)}>
         {detailDoctorId && <DoctorDetail doctorId={detailDoctorId} />}
-      </Modal>
-
-      <Modal isOpen={showAddDoctor} onClose={() => setShowAddDoctor(false)}>
-        <FormDoctor onFinish={() => setShowAddDoctor(false)} />
       </Modal>
 
       <Modal isOpen={editDoctorId !== null} onClose={() => setEditDoctorId(null)}>

--- a/M8MED/src/pages/DashboardMedico.tsx
+++ b/M8MED/src/pages/DashboardMedico.tsx
@@ -39,6 +39,14 @@ export default function DashboardMedico() {
     [pacientesAll, doctor.id]
   )
 
+  const pacienteMap = useMemo(() => {
+    const map: Record<string, string> = {}
+    pacientes.forEach((p) => {
+      map[p.id] = `${p.nombre} ${p.apellido}`
+    })
+    return map
+  }, [pacientes])
+
   const turnosDoctor = useMemo(
     () => turnosAll.filter((t) => t.doctorId === doctor.id),
     [turnosAll, doctor.id]
@@ -97,35 +105,31 @@ export default function DashboardMedico() {
             <p className="text-slate-600">No hay turnos registrados.</p>
           ) : (
             <ul className="space-y-2">
-              {turnosDoctor.map((t) => {
-                const pac = pacientes.find((p) => p.id === t.pacienteId)
-                return (
-                  <li
-                    key={t.id}
-                    className="bg-white rounded shadow p-2 flex justify-between items-center"
-                  >
-                    <span>
-                      {t.fecha} {t.hora} - {pac?.nombre} {pac?.apellido} (
-                      {t.tipo})
-                      {t.descripcion ? ` - ${t.descripcion}` : ''}
-                    </span>
-                    <div className="space-x-4">
-                      <button
-                        onClick={() => setEditTurnoId(t.id)}
-                        className="text-sky-600 hover:underline"
-                      >
-                        Editar
-                      </button>
-                      <button
-                        onClick={() => eliminarTurno(t.id)}
-                        className="text-red-600 hover:underline"
-                      >
-                        Cancelar
-                      </button>
-                    </div>
-                  </li>
-                )
-              })}
+              {turnosDoctor.map((t) => (
+                <li
+                  key={t.id}
+                  className="bg-white rounded shadow p-2 flex justify-between items-center"
+                >
+                  <span>
+                    {t.fecha} {t.hora} - {pacienteMap[t.pacienteId]} ({t.tipo})
+                    {t.descripcion ? ` - ${t.descripcion}` : ''}
+                  </span>
+                  <div className="space-x-4">
+                    <button
+                      onClick={() => setEditTurnoId(t.id)}
+                      className="text-sky-600 hover:underline"
+                    >
+                      Editar
+                    </button>
+                    <button
+                      onClick={() => eliminarTurno(t.id)}
+                      className="text-red-600 hover:underline"
+                    >
+                      Cancelar
+                    </button>
+                  </div>
+                </li>
+              ))}
             </ul>
           )}
         </div>

--- a/M8MED/src/pages/DashboardMedico.tsx
+++ b/M8MED/src/pages/DashboardMedico.tsx
@@ -7,6 +7,7 @@ import { useUserStore } from '../store/useUserStore'
 import { usePacienteStore } from '../store/usePacienteStore'
 import { useTurnoStore } from '../store/useTurnoStore'
 import FormPaciente from '../components/FormPaciente'
+import FormTurno from '../components/FormTurno'
 import PatientDetail from './PatientDetail'
 
 export default function DashboardMedico() {
@@ -15,7 +16,6 @@ export default function DashboardMedico() {
   const cirugias = useM8Store((s) => s.cirugias)
   const pacientesAll = usePacienteStore((s) => s.pacientes)
   const turnosAll = useTurnoStore((s) => s.turnos)
-  const agregarTurno = useTurnoStore((s) => s.agregarTurno)
   const eliminarTurno = useTurnoStore((s) => s.eliminarTurno)
 
   // Buscar el médico según el id del usuario. Si no existe, usar el primero.
@@ -48,7 +48,7 @@ export default function DashboardMedico() {
   const [addPatient, setAddPatient] = useState(false)
   const [detailPatientId, setDetailPatientId] = useState<string | null>(null)
   const [addTurno, setAddTurno] = useState(false)
-  const [nuevoTurno, setNuevoTurno] = useState({ pacienteId: '', fecha: '', hora: '' })
+  const [editTurnoId, setEditTurnoId] = useState<string | null>(null)
 
   const eventos = useMemo(
     () => [
@@ -100,13 +100,27 @@ export default function DashboardMedico() {
               {turnosDoctor.map((t) => {
                 const pac = pacientes.find((p) => p.id === t.pacienteId)
                 return (
-                  <li key={t.id} className="bg-white rounded shadow p-2 flex justify-between items-center">
+                  <li
+                    key={t.id}
+                    className="bg-white rounded shadow p-2 flex justify-between items-center"
+                  >
                     <span>
                       {t.fecha} {t.hora} - {pac?.nombre} {pac?.apellido}
                     </span>
-                    <button onClick={() => eliminarTurno(t.id)} className="text-red-600 hover:underline">
-                      Cancelar
-                    </button>
+                    <div className="space-x-4">
+                      <button
+                        onClick={() => setEditTurnoId(t.id)}
+                        className="text-sky-600 hover:underline"
+                      >
+                        Editar
+                      </button>
+                      <button
+                        onClick={() => eliminarTurno(t.id)}
+                        className="text-red-600 hover:underline"
+                      >
+                        Cancelar
+                      </button>
+                    </div>
                   </li>
                 )
               })}
@@ -181,57 +195,20 @@ export default function DashboardMedico() {
       </Modal>
 
       <Modal isOpen={addTurno} onClose={() => setAddTurno(false)}>
-        <form
-          onSubmit={(e) => {
-            e.preventDefault()
-            if (!nuevoTurno.pacienteId) return
-            agregarTurno({
-              doctorId: doctor.id,
-              pacienteId: nuevoTurno.pacienteId,
-              fecha: nuevoTurno.fecha,
-              hora: nuevoTurno.hora,
-            })
-            setNuevoTurno({ pacienteId: '', fecha: '', hora: '' })
-            setAddTurno(false)
-          }}
-          className="space-y-4"
-        >
-          <select
-            name="pacienteId"
-            value={nuevoTurno.pacienteId}
-            onChange={(e) => setNuevoTurno({ ...nuevoTurno, pacienteId: e.target.value })}
-            className="input w-full"
-            required
-          >
-            <option value="" disabled>
-              Seleccione paciente
-            </option>
-            {pacientes.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.nombre} {p.apellido}
-              </option>
-            ))}
-          </select>
-          <input
-            type="date"
-            name="fecha"
-            value={nuevoTurno.fecha}
-            onChange={(e) => setNuevoTurno({ ...nuevoTurno, fecha: e.target.value })}
-            className="input w-full"
-            required
+        <FormTurno
+          doctorIdFixed={doctor.id}
+          onFinish={() => setAddTurno(false)}
+        />
+      </Modal>
+
+      <Modal isOpen={editTurnoId !== null} onClose={() => setEditTurnoId(null)}>
+        {editTurnoId && (
+          <FormTurno
+            turno={turnosDoctor.find((t) => t.id === editTurnoId)}
+            doctorIdFixed={doctor.id}
+            onFinish={() => setEditTurnoId(null)}
           />
-          <input
-            type="time"
-            name="hora"
-            value={nuevoTurno.hora}
-            onChange={(e) => setNuevoTurno({ ...nuevoTurno, hora: e.target.value })}
-            className="input w-full"
-            required
-          />
-          <button type="submit" className="btn w-full">
-            Guardar turno
-          </button>
-        </form>
+        )}
       </Modal>
     </>
   )

--- a/M8MED/src/pages/DashboardMedico.tsx
+++ b/M8MED/src/pages/DashboardMedico.tsx
@@ -5,12 +5,18 @@ import Calendar from '../components/Calendar'
 import { useM8Store } from '../store/useM8Store'
 import { useUserStore } from '../store/useUserStore'
 import { usePacienteStore } from '../store/usePacienteStore'
+import { useTurnoStore } from '../store/useTurnoStore'
+import FormPaciente from '../components/FormPaciente'
+import PatientDetail from './PatientDetail'
 
 export default function DashboardMedico() {
   const user = useUserStore((s) => s.user)
   const doctores = useM8Store((s) => s.doctores)
   const cirugias = useM8Store((s) => s.cirugias)
   const pacientesAll = usePacienteStore((s) => s.pacientes)
+  const turnosAll = useTurnoStore((s) => s.turnos)
+  const agregarTurno = useTurnoStore((s) => s.agregarTurno)
+  const eliminarTurno = useTurnoStore((s) => s.eliminarTurno)
 
   // Buscar el médico según el id del usuario. Si no existe, usar el primero.
   const doctor = useMemo(() => {
@@ -33,14 +39,23 @@ export default function DashboardMedico() {
     [pacientesAll, doctor.id]
   )
 
+  const turnosDoctor = useMemo(
+    () => turnosAll.filter((t) => t.doctorId === doctor.id),
+    [turnosAll, doctor.id]
+  )
+
   const [showPopup, setShowPopup] = useState(false)
+  const [addPatient, setAddPatient] = useState(false)
+  const [detailPatientId, setDetailPatientId] = useState<string | null>(null)
+  const [addTurno, setAddTurno] = useState(false)
+  const [nuevoTurno, setNuevoTurno] = useState({ pacienteId: '', fecha: '', hora: '' })
 
   const eventos = useMemo(
-    () =>
-      cirugiasDoctor.map((c) => ({
-        date: c.fecha,
-      })),
-    [cirugiasDoctor]
+    () => [
+      ...cirugiasDoctor.map((c) => ({ date: c.fecha })),
+      ...turnosDoctor.map((t) => ({ date: t.fecha })),
+    ],
+    [cirugiasDoctor, turnosDoctor]
   )
 
   const obtenerMonto = (c: (typeof cirugiasDoctor)[number]) => {
@@ -69,22 +84,58 @@ export default function DashboardMedico() {
         </div>
 
         <div>
-          <h2 className="text-xl font-semibold mb-2">Próximos turnos</h2>
+          <h2 className="text-xl font-semibold mb-2">Calendario</h2>
           <Calendar events={eventos} />
         </div>
 
         <div>
-          <h2 className="text-xl font-semibold mb-2">Mis pacientes</h2>
+          <div className="flex justify-between items-center mb-2">
+            <h2 className="text-xl font-semibold">Mis turnos</h2>
+            <button className="btn" onClick={() => setAddTurno(true)}>+ Agendar turno</button>
+          </div>
+          {turnosDoctor.length === 0 ? (
+            <p className="text-slate-600">No hay turnos registrados.</p>
+          ) : (
+            <ul className="space-y-2">
+              {turnosDoctor.map((t) => {
+                const pac = pacientes.find((p) => p.id === t.pacienteId)
+                return (
+                  <li key={t.id} className="bg-white rounded shadow p-2 flex justify-between items-center">
+                    <span>
+                      {t.fecha} {t.hora} - {pac?.nombre} {pac?.apellido}
+                    </span>
+                    <button onClick={() => eliminarTurno(t.id)} className="text-red-600 hover:underline">
+                      Cancelar
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div>
+          <div className="flex justify-between items-center mb-2">
+            <h2 className="text-xl font-semibold">Mis pacientes</h2>
+            <button className="btn" onClick={() => setAddPatient(true)}>+ Agregar</button>
+          </div>
           {pacientes.length === 0 ? (
             <p className="text-slate-600">Aún no tiene pacientes.</p>
           ) : (
-            <ul className="list-disc pl-5 space-y-1">
-              {pacientes.map((p, i) => (
-                <li key={i}>
-                  {p.nombre} {p.apellido}
-                </li>
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {pacientes.map((p) => (
+                <div key={p.id} className="card hover:shadow-md transition-shadow">
+                  <h3 className="text-lg font-semibold text-slate-800">
+                    {p.nombre} {p.apellido}
+                  </h3>
+                  <p className="text-sm text-slate-600">{p.telefono}</p>
+                  <p className="text-sm text-slate-600 mb-2">{p.email}</p>
+                  <button onClick={() => setDetailPatientId(p.id)} className="text-sky-600 hover:underline">
+                    Ver historial
+                  </button>
+                </div>
               ))}
-            </ul>
+            </div>
           )}
         </div>
       </div>
@@ -119,6 +170,68 @@ export default function DashboardMedico() {
             </table>
           </div>
         )}
+      </Modal>
+
+      <Modal isOpen={addPatient} onClose={() => setAddPatient(false)}>
+        <FormPaciente doctorIdFixed={doctor.id} onFinish={() => setAddPatient(false)} />
+      </Modal>
+
+      <Modal isOpen={detailPatientId !== null} onClose={() => setDetailPatientId(null)}>
+        {detailPatientId && <PatientDetail pacienteId={detailPatientId} />}
+      </Modal>
+
+      <Modal isOpen={addTurno} onClose={() => setAddTurno(false)}>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            if (!nuevoTurno.pacienteId) return
+            agregarTurno({
+              doctorId: doctor.id,
+              pacienteId: nuevoTurno.pacienteId,
+              fecha: nuevoTurno.fecha,
+              hora: nuevoTurno.hora,
+            })
+            setNuevoTurno({ pacienteId: '', fecha: '', hora: '' })
+            setAddTurno(false)
+          }}
+          className="space-y-4"
+        >
+          <select
+            name="pacienteId"
+            value={nuevoTurno.pacienteId}
+            onChange={(e) => setNuevoTurno({ ...nuevoTurno, pacienteId: e.target.value })}
+            className="input w-full"
+            required
+          >
+            <option value="" disabled>
+              Seleccione paciente
+            </option>
+            {pacientes.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.nombre} {p.apellido}
+              </option>
+            ))}
+          </select>
+          <input
+            type="date"
+            name="fecha"
+            value={nuevoTurno.fecha}
+            onChange={(e) => setNuevoTurno({ ...nuevoTurno, fecha: e.target.value })}
+            className="input w-full"
+            required
+          />
+          <input
+            type="time"
+            name="hora"
+            value={nuevoTurno.hora}
+            onChange={(e) => setNuevoTurno({ ...nuevoTurno, hora: e.target.value })}
+            className="input w-full"
+            required
+          />
+          <button type="submit" className="btn w-full">
+            Guardar turno
+          </button>
+        </form>
       </Modal>
     </>
   )

--- a/M8MED/src/pages/DashboardMedico.tsx
+++ b/M8MED/src/pages/DashboardMedico.tsx
@@ -1,13 +1,132 @@
+import { useState, useMemo } from 'react'
 import Navbar from '../components/Navbar'
+import Modal from '../components/Modal'
+import Calendar from '../components/Calendar'
+import { useM8Store } from '../store/useM8Store'
+import { useUserStore } from '../store/useUserStore'
 
 export default function DashboardMedico() {
+  const user = useUserStore((s) => s.user)
+  const doctores = useM8Store((s) => s.doctores)
+  const cirugias = useM8Store((s) => s.cirugias)
+
+  // Buscar el médico según el email del usuario. Si no existe, usar el primero.
+  const doctor = useMemo(() => {
+    if (!user) return doctores[0]
+    return doctores.find((d) => d.email === user.email) ?? doctores[0]
+  }, [user, doctores])
+
+  // Cirugías donde participa el médico
+  const cirugiasDoctor = useMemo(
+    () =>
+      cirugias.filter(
+        (c) => c.doctorId === doctor.id || c.ayudantes.includes(doctor.id)
+      ),
+    [cirugias, doctor.id]
+  )
+
+  // Pacientes únicos asociados al médico
+  const pacientes = useMemo(() => {
+    const mapa = new Map<string, { nombre: string; apellido: string }>()
+    cirugiasDoctor.forEach((c) => {
+      const dni = c.paciente.dni
+      if (!mapa.has(dni)) {
+        mapa.set(dni, {
+          nombre: c.paciente.nombre,
+          apellido: '',
+        })
+      }
+    })
+    return Array.from(mapa.values())
+  }, [cirugiasDoctor])
+
+  const [showPopup, setShowPopup] = useState(false)
+
+  const eventos = useMemo(
+    () =>
+      cirugiasDoctor.map((c) => ({
+        date: c.fecha,
+      })),
+    [cirugiasDoctor]
+  )
+
+  const obtenerMonto = (c: (typeof cirugiasDoctor)[number]) => {
+    const partes = 1 + c.ayudantes.length
+    return c.valorBase / partes
+  }
+
   return (
     <>
       <Navbar />
-      <div className="p-6">
-        <h1 className="text-2xl font-bold mb-4">Panel Médico</h1>
-        <p>Mis pacientes, turnos y recetas</p>
+      <div className="pt-20 max-w-4xl mx-auto p-6 space-y-8">
+        <h1 className="text-3xl font-semibold">
+          Bienvenido, {doctor.nombre}
+        </h1>
+
+        <div>
+          <div
+            className="card cursor-pointer"
+            onClick={() => setShowPopup(true)}
+          >
+            <h2 className="text-lg font-medium mb-1">Ingresos actuales</h2>
+            <p className="text-2xl font-bold">
+              ${doctor.sueldo.toFixed(2)}
+            </p>
+          </div>
+        </div>
+
+        <div>
+          <h2 className="text-xl font-semibold mb-2">Próximos turnos</h2>
+          <Calendar events={eventos} />
+        </div>
+
+        <div>
+          <h2 className="text-xl font-semibold mb-2">Mis pacientes</h2>
+          {pacientes.length === 0 ? (
+            <p className="text-slate-600">Aún no tiene pacientes.</p>
+          ) : (
+            <ul className="list-disc pl-5 space-y-1">
+              {pacientes.map((p, i) => (
+                <li key={i}>
+                  {p.nombre} {p.apellido}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </div>
+
+      <Modal isOpen={showPopup} onClose={() => setShowPopup(false)}>
+        <h2 className="text-xl font-bold mb-4">Ingresos por cirugía</h2>
+        {cirugiasDoctor.length === 0 ? (
+          <p>No hay cirugías registradas.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-100 text-gray-700 text-left">
+                <tr>
+                  <th className="px-4 py-2">Fecha</th>
+                  <th className="px-4 py-2">Paciente</th>
+                  <th className="px-4 py-2">Monto</th>
+                </tr>
+              </thead>
+              <tbody>
+                {cirugiasDoctor.map((c) => (
+                  <tr key={c.id} className="border-b">
+                    <td className="px-4 py-2">{c.fecha}</td>
+                    <td className="px-4 py-2">
+                      {c.paciente.nombre} ({c.paciente.dni})
+                    </td>
+                    <td className="px-4 py-2">
+                      ${obtenerMonto(c).toFixed(2)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Modal>
     </>
   )
 }

--- a/M8MED/src/pages/DashboardMedico.tsx
+++ b/M8MED/src/pages/DashboardMedico.tsx
@@ -74,10 +74,15 @@ export default function DashboardMedico() {
   return (
     <>
       <Navbar />
-      <div className="pt-20 max-w-4xl mx-auto p-6 space-y-8">
-        <h1 className="text-3xl font-semibold">
-          Bienvenido, {doctor.nombre}
-        </h1>
+      <header className="bg-white shadow">
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+            Bienvenido, {doctor.nombre}
+          </h1>
+        </div>
+      </header>
+      <main>
+        <div className="mx-auto max-w-4xl px-4 py-6 sm:px-6 lg:px-8 space-y-8">
 
         <div>
           <div
@@ -139,26 +144,27 @@ export default function DashboardMedico() {
             <h2 className="text-xl font-semibold">Mis pacientes</h2>
             <button className="btn" onClick={() => setAddPatient(true)}>+ Agregar</button>
           </div>
-          {pacientes.length === 0 ? (
-            <p className="text-slate-600">Aún no tiene pacientes.</p>
-          ) : (
-            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-              {pacientes.map((p) => (
-                <div key={p.id} className="card hover:shadow-md transition-shadow">
-                  <h3 className="text-lg font-semibold text-slate-800">
-                    {p.nombre} {p.apellido}
-                  </h3>
-                  <p className="text-sm text-slate-600">{p.telefono}</p>
-                  <p className="text-sm text-slate-600 mb-2">{p.email}</p>
-                  <button onClick={() => setDetailPatientId(p.id)} className="text-sky-600 hover:underline">
-                    Ver historial
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
+        {pacientes.length === 0 ? (
+          <p className="text-slate-600">Aún no tiene pacientes.</p>
+        ) : (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {pacientes.map((p) => (
+              <div key={p.id} className="card hover:shadow-md transition-shadow">
+                <h3 className="text-lg font-semibold text-slate-800">
+                  {p.nombre} {p.apellido}
+                </h3>
+                <p className="text-sm text-slate-600">{p.telefono}</p>
+                <p className="text-sm text-slate-600 mb-2">{p.email}</p>
+                <button onClick={() => setDetailPatientId(p.id)} className="text-sky-600 hover:underline">
+                  Ver historial
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
         </div>
-      </div>
+        </div>
+      </main>
 
       <Modal isOpen={showPopup} onClose={() => setShowPopup(false)}>
         <h2 className="text-xl font-bold mb-4">Ingresos por cirugía</h2>

--- a/M8MED/src/pages/DashboardMedico.tsx
+++ b/M8MED/src/pages/DashboardMedico.tsx
@@ -10,10 +10,10 @@ export default function DashboardMedico() {
   const doctores = useM8Store((s) => s.doctores)
   const cirugias = useM8Store((s) => s.cirugias)
 
-  // Buscar el médico según el email del usuario. Si no existe, usar el primero.
+  // Buscar el médico según el id del usuario. Si no existe, usar el primero.
   const doctor = useMemo(() => {
     if (!user) return doctores[0]
-    return doctores.find((d) => d.email === user.email) ?? doctores[0]
+    return doctores.find((d) => d.id === user.id) ?? doctores[0]
   }, [user, doctores])
 
   // Cirugías donde participa el médico

--- a/M8MED/src/pages/DashboardMedico.tsx
+++ b/M8MED/src/pages/DashboardMedico.tsx
@@ -105,7 +105,9 @@ export default function DashboardMedico() {
                     className="bg-white rounded shadow p-2 flex justify-between items-center"
                   >
                     <span>
-                      {t.fecha} {t.hora} - {pac?.nombre} {pac?.apellido}
+                      {t.fecha} {t.hora} - {pac?.nombre} {pac?.apellido} (
+                      {t.tipo})
+                      {t.descripcion ? ` - ${t.descripcion}` : ''}
                     </span>
                     <div className="space-x-4">
                       <button

--- a/M8MED/src/pages/DashboardMedico.tsx
+++ b/M8MED/src/pages/DashboardMedico.tsx
@@ -1,75 +1,75 @@
-import { useState, useMemo } from 'react'
-import Navbar from '../components/Navbar'
-import Modal from '../components/Modal'
-import Calendar from '../components/Calendar'
-import { useM8Store } from '../store/useM8Store'
-import { useUserStore } from '../store/useUserStore'
-import { usePacienteStore } from '../store/usePacienteStore'
-import { useTurnoStore } from '../store/useTurnoStore'
-import FormPaciente from '../components/FormPaciente'
-import FormTurno from '../components/FormTurno'
-import PatientDetail from './PatientDetail'
+import { useState, useMemo } from 'react';
+import Navbar from '../components/Navbar';
+import Modal from '../components/Modal';
+import Calendar from '../components/Calendar';
+import { useM8Store } from '../store/useM8Store';
+import { useUserStore } from '../store/useUserStore';
+import { usePacienteStore } from '../store/usePacienteStore';
+import { useTurnoStore } from '../store/useTurnoStore';
+import FormPaciente from '../components/FormPaciente';
+import FormTurno from '../components/FormTurno';
+import PatientDetail from './PatientDetail';
 
 export default function DashboardMedico() {
-  const user = useUserStore((s) => s.user)
-  const doctores = useM8Store((s) => s.doctores)
-  const cirugias = useM8Store((s) => s.cirugias)
-  const pacientesAll = usePacienteStore((s) => s.pacientes)
-  const turnosAll = useTurnoStore((s) => s.turnos)
-  const eliminarTurno = useTurnoStore((s) => s.eliminarTurno)
+  const user = useUserStore((s) => s.user);
+  const doctores = useM8Store((s) => s.doctores);
+  const cirugias = useM8Store((s) => s.cirugias);
+  const pacientesAll = usePacienteStore((s) => s.pacientes);
+  const turnosAll = useTurnoStore((s) => s.turnos);
+  const eliminarTurno = useTurnoStore((s) => s.eliminarTurno);
 
   // Buscar el médico según el id del usuario. Si no existe, usar el primero.
   const doctor = useMemo(() => {
-    if (!user) return doctores[0]
-    return doctores.find((d) => d.id === user.id) ?? doctores[0]
-  }, [user, doctores])
+    if (!user) return doctores[0];
+    return doctores.find((d) => d.id === user.id) ?? doctores[0];
+  }, [user, doctores]);
 
   // Cirugías donde participa el médico
   const cirugiasDoctor = useMemo(
     () =>
       cirugias.filter(
-        (c) => c.doctorId === doctor.id || c.ayudantes.includes(doctor.id)
+        (c) => c.doctorId === doctor.id || c.ayudantes.includes(doctor.id),
       ),
-    [cirugias, doctor.id]
-  )
+    [cirugias, doctor.id],
+  );
 
   // Pacientes asociados al médico
   const pacientes = useMemo(
     () => pacientesAll.filter((p) => p.doctorId === doctor.id),
-    [pacientesAll, doctor.id]
-  )
+    [pacientesAll, doctor.id],
+  );
 
   const pacienteMap = useMemo(() => {
-    const map: Record<string, string> = {}
+    const map: Record<string, string> = {};
     pacientes.forEach((p) => {
-      map[p.id] = `${p.nombre} ${p.apellido}`
-    })
-    return map
-  }, [pacientes])
+      map[p.id] = `${p.nombre} ${p.apellido}`;
+    });
+    return map;
+  }, [pacientes]);
 
   const turnosDoctor = useMemo(
     () => turnosAll.filter((t) => t.doctorId === doctor.id),
-    [turnosAll, doctor.id]
-  )
+    [turnosAll, doctor.id],
+  );
 
-  const [showPopup, setShowPopup] = useState(false)
-  const [addPatient, setAddPatient] = useState(false)
-  const [detailPatientId, setDetailPatientId] = useState<string | null>(null)
-  const [addTurno, setAddTurno] = useState(false)
-  const [editTurnoId, setEditTurnoId] = useState<string | null>(null)
+  const [showPopup, setShowPopup] = useState(false);
+  const [addPatient, setAddPatient] = useState(false);
+  const [detailPatientId, setDetailPatientId] = useState<string | null>(null);
+  const [addTurno, setAddTurno] = useState(false);
+  const [editTurnoId, setEditTurnoId] = useState<string | null>(null);
 
   const eventos = useMemo(
     () => [
       ...cirugiasDoctor.map((c) => ({ date: c.fecha })),
       ...turnosDoctor.map((t) => ({ date: t.fecha })),
     ],
-    [cirugiasDoctor, turnosDoctor]
-  )
+    [cirugiasDoctor, turnosDoctor],
+  );
 
   const obtenerMonto = (c: (typeof cirugiasDoctor)[number]) => {
-    const partes = 1 + c.ayudantes.length
-    return c.valorBase / partes
-  }
+    const partes = 1 + c.ayudantes.length;
+    return c.valorBase / partes;
+  };
 
   return (
     <>
@@ -83,86 +83,93 @@ export default function DashboardMedico() {
       </header>
       <main>
         <div className="mx-auto max-w-4xl px-4 py-6 sm:px-6 lg:px-8 space-y-8">
-
-        <div>
-          <div
-            className="card cursor-pointer"
-            onClick={() => setShowPopup(true)}
-          >
-            <h2 className="text-lg font-medium mb-1">Ingresos actuales</h2>
-            <p className="text-2xl font-bold">
-              ${doctor.sueldo.toFixed(2)}
-            </p>
+          <div>
+            <div
+              className="card cursor-pointer"
+              onClick={() => setShowPopup(true)}
+            >
+              <h2 className="text-lg font-medium mb-1">Ingresos actuales</h2>
+              <p className="text-2xl font-bold">${doctor.sueldo.toFixed(2)}</p>
+            </div>
           </div>
-        </div>
 
-        <div>
-          <h2 className="text-xl font-semibold mb-2">Calendario</h2>
-          <Calendar events={eventos} />
-        </div>
-
-        <div>
-          <div className="flex justify-between items-center mb-2">
-            <h2 className="text-xl font-semibold">Mis turnos</h2>
-            <button className="btn" onClick={() => setAddTurno(true)}>+ Agendar turno</button>
+          <div>
+            <h2 className="text-xl font-semibold mb-2">Calendario</h2>
+            <Calendar events={eventos} />
           </div>
-          {turnosDoctor.length === 0 ? (
-            <p className="text-slate-600">No hay turnos registrados.</p>
-          ) : (
-            <ul className="space-y-2">
-              {turnosDoctor.map((t) => (
-                <li
-                  key={t.id}
-                  className="bg-white rounded shadow p-2 flex justify-between items-center"
-                >
-                  <span>
-                    {t.fecha} {t.hora} - {pacienteMap[t.pacienteId]} ({t.tipo})
-                    {t.descripcion ? ` - ${t.descripcion}` : ''}
-                  </span>
-                  <div className="space-x-4">
+
+          <div>
+            <div className="flex justify-between items-center mb-2">
+              <h2 className="text-xl font-semibold">Mis turnos</h2>
+              <button className="btn" onClick={() => setAddTurno(true)}>
+                + Agendar turno
+              </button>
+            </div>
+            {turnosDoctor.length === 0 ? (
+              <p className="text-slate-600">No hay turnos registrados.</p>
+            ) : (
+              <ul className="space-y-2">
+                {turnosDoctor.map((t) => (
+                  <li
+                    key={t.id}
+                    className="bg-white rounded shadow p-2 flex justify-between items-center"
+                  >
+                    <span>
+                      {t.fecha} {t.hora} - {pacienteMap[t.pacienteId]} ({t.tipo}
+                      ){t.descripcion ? ` - ${t.descripcion}` : ''}
+                    </span>
+                    <div className="space-x-4">
+                      <button
+                        onClick={() => setEditTurnoId(t.id)}
+                        className="text-sky-600 hover:underline"
+                      >
+                        Editar
+                      </button>
+                      <button
+                        onClick={() => eliminarTurno(t.id)}
+                        className="text-red-600 hover:underline"
+                      >
+                        Cancelar
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div>
+            <div className="flex justify-between items-center mb-2">
+              <h2 className="text-xl font-semibold">Mis pacientes</h2>
+              <button className="btn" onClick={() => setAddPatient(true)}>
+                + Agregar
+              </button>
+            </div>
+            {pacientes.length === 0 ? (
+              <p className="text-slate-600">Aún no tiene pacientes.</p>
+            ) : (
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                {pacientes.map((p) => (
+                  <div
+                    key={p.id}
+                    className="card hover:shadow-md transition-shadow"
+                  >
+                    <h3 className="text-lg font-semibold text-slate-800">
+                      {p.nombre} {p.apellido}
+                    </h3>
+                    <p className="text-sm text-slate-600">{p.telefono}</p>
+                    <p className="text-sm text-slate-600 mb-2">{p.email}</p>
                     <button
-                      onClick={() => setEditTurnoId(t.id)}
+                      onClick={() => setDetailPatientId(p.id)}
                       className="text-sky-600 hover:underline"
                     >
-                      Editar
-                    </button>
-                    <button
-                      onClick={() => eliminarTurno(t.id)}
-                      className="text-red-600 hover:underline"
-                    >
-                      Cancelar
+                      Ver historial
                     </button>
                   </div>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-
-        <div>
-          <div className="flex justify-between items-center mb-2">
-            <h2 className="text-xl font-semibold">Mis pacientes</h2>
-            <button className="btn" onClick={() => setAddPatient(true)}>+ Agregar</button>
-          </div>
-        {pacientes.length === 0 ? (
-          <p className="text-slate-600">Aún no tiene pacientes.</p>
-        ) : (
-          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {pacientes.map((p) => (
-              <div key={p.id} className="card hover:shadow-md transition-shadow">
-                <h3 className="text-lg font-semibold text-slate-800">
-                  {p.nombre} {p.apellido}
-                </h3>
-                <p className="text-sm text-slate-600">{p.telefono}</p>
-                <p className="text-sm text-slate-600 mb-2">{p.email}</p>
-                <button onClick={() => setDetailPatientId(p.id)} className="text-sky-600 hover:underline">
-                  Ver historial
-                </button>
+                ))}
               </div>
-            ))}
+            )}
           </div>
-        )}
-        </div>
         </div>
       </main>
 
@@ -187,9 +194,7 @@ export default function DashboardMedico() {
                     <td className="px-4 py-2">
                       {c.paciente.nombre} ({c.paciente.dni})
                     </td>
-                    <td className="px-4 py-2">
-                      ${obtenerMonto(c).toFixed(2)}
-                    </td>
+                    <td className="px-4 py-2">${obtenerMonto(c).toFixed(2)}</td>
                   </tr>
                 ))}
               </tbody>
@@ -199,10 +204,16 @@ export default function DashboardMedico() {
       </Modal>
 
       <Modal isOpen={addPatient} onClose={() => setAddPatient(false)}>
-        <FormPaciente doctorIdFixed={doctor.id} onFinish={() => setAddPatient(false)} />
+        <FormPaciente
+          doctorIdFixed={doctor.id}
+          onFinish={() => setAddPatient(false)}
+        />
       </Modal>
 
-      <Modal isOpen={detailPatientId !== null} onClose={() => setDetailPatientId(null)}>
+      <Modal
+        isOpen={detailPatientId !== null}
+        onClose={() => setDetailPatientId(null)}
+      >
         {detailPatientId && <PatientDetail pacienteId={detailPatientId} />}
       </Modal>
 
@@ -223,5 +234,5 @@ export default function DashboardMedico() {
         )}
       </Modal>
     </>
-  )
+  );
 }

--- a/M8MED/src/pages/DashboardMedico.tsx
+++ b/M8MED/src/pages/DashboardMedico.tsx
@@ -4,11 +4,13 @@ import Modal from '../components/Modal'
 import Calendar from '../components/Calendar'
 import { useM8Store } from '../store/useM8Store'
 import { useUserStore } from '../store/useUserStore'
+import { usePacienteStore } from '../store/usePacienteStore'
 
 export default function DashboardMedico() {
   const user = useUserStore((s) => s.user)
   const doctores = useM8Store((s) => s.doctores)
   const cirugias = useM8Store((s) => s.cirugias)
+  const pacientesAll = usePacienteStore((s) => s.pacientes)
 
   // Buscar el médico según el id del usuario. Si no existe, usar el primero.
   const doctor = useMemo(() => {
@@ -25,20 +27,11 @@ export default function DashboardMedico() {
     [cirugias, doctor.id]
   )
 
-  // Pacientes únicos asociados al médico
-  const pacientes = useMemo(() => {
-    const mapa = new Map<string, { nombre: string; apellido: string }>()
-    cirugiasDoctor.forEach((c) => {
-      const dni = c.paciente.dni
-      if (!mapa.has(dni)) {
-        mapa.set(dni, {
-          nombre: c.paciente.nombre,
-          apellido: '',
-        })
-      }
-    })
-    return Array.from(mapa.values())
-  }, [cirugiasDoctor])
+  // Pacientes asociados al médico
+  const pacientes = useMemo(
+    () => pacientesAll.filter((p) => p.doctorId === doctor.id),
+    [pacientesAll, doctor.id]
+  )
 
   const [showPopup, setShowPopup] = useState(false)
 

--- a/M8MED/src/pages/DoctorDetail.tsx
+++ b/M8MED/src/pages/DoctorDetail.tsx
@@ -1,57 +1,56 @@
-import { Link } from 'react-router-dom'
-import { useM8Store } from '../store/useM8Store'
-import { useState, useMemo } from 'react'
-import type { Surgery } from '../store/useM8Store'
-import { meses, ultimosAnios } from '../lib/date'
+import { Link } from 'react-router-dom';
+import { useM8Store } from '../store/useM8Store';
+import { useState, useMemo } from 'react';
+import type { Surgery } from '../store/useM8Store';
+import { meses, ultimosAnios } from '../lib/date';
 
 type Props = {
-  doctorId: string
-}
+  doctorId: string;
+};
 export default function DoctorDetail({ doctorId }: Props) {
   // Obtenemos las referencias originales de doctores y cirugías
-  const doctores = useM8Store((state) => state.doctores)
-  const cirugias = useM8Store((state) => state.cirugias)
-  const doctor = doctores.find((d) => d.id === doctorId)
+  const doctores = useM8Store((state) => state.doctores);
+  const cirugias = useM8Store((state) => state.cirugias);
+  const doctor = doctores.find((d) => d.id === doctorId);
 
   // Mapeamos IDs de doctores a nombres usando useMemo
   const doctorNames = useMemo(() => {
-    const map: Record<string, string> = {}
+    const map: Record<string, string> = {};
     doctores.forEach((d) => {
-      map[d.id] = `${d.nombre} ${d.apellido}`
-    })
-    return map
-  }, [doctores])
+      map[d.id] = `${d.nombre} ${d.apellido}`;
+    });
+    return map;
+  }, [doctores]);
 
   // Estados para filtrar por mes y año
-  const ahora = new Date()
-  const [mesFiltro, setMesFiltro] = useState<number>(ahora.getMonth() + 1)
-  const [anioFiltro, setAnioFiltro] = useState<number>(ahora.getFullYear())
+  const ahora = new Date();
+  const [mesFiltro, setMesFiltro] = useState<number>(ahora.getMonth() + 1);
+  const [anioFiltro, setAnioFiltro] = useState<number>(ahora.getFullYear());
 
   // Calcula el monto asignado a este médico para cada cirugía usando valorBase
   const obtenerMonto = (c: Surgery) => {
-    const partes = 1 + c.ayudantes.length
-    return c.valorBase / partes
-  }
+    const partes = 1 + c.ayudantes.length;
+    return c.valorBase / partes;
+  };
 
-  const anios = useMemo(() => ultimosAnios(), [])
+  const anios = useMemo(() => ultimosAnios(), []);
 
   if (!doctor) {
     return (
       <div className="p-6">
         <p>Médico no encontrado.</p>
       </div>
-    )
+    );
   }
 
   // Filtramos las cirugías del médico según mes y año seleccionados
   const cirugiasDelMedico = cirugias.filter((c) => {
-    if (c.doctorId !== doctor.id) return false
-    const fecha = new Date(`${c.fecha}T${c.hora}`)
+    if (c.doctorId !== doctor.id) return false;
+    const fecha = new Date(`${c.fecha}T${c.hora}`);
     return (
-      fecha.getMonth() + 1 === mesFiltro &&
-      fecha.getFullYear() === anioFiltro
-    )
-  })
+      fecha.getMonth() + 1 === mesFiltro && fecha.getFullYear() === anioFiltro
+    );
+  });
 
   return (
     <div className="p-6 bg-white rounded-xl shadow max-w-3xl mx-auto">
@@ -139,9 +138,7 @@ export default function DoctorDetail({ doctorId }: Props) {
                       .map((aid) => doctorNames[aid] ?? aid)
                       .join(', ')}
                   </td>
-                  <td className="px-4 py-2">
-                    ${obtenerMonto(c).toFixed(2)}
-                  </td>
+                  <td className="px-4 py-2">${obtenerMonto(c).toFixed(2)}</td>
                   <td className="px-4 py-2">
                     {c.imagen ? (
                       <img
@@ -167,5 +164,5 @@ export default function DoctorDetail({ doctorId }: Props) {
         Cargar nueva cirugía
       </Link>
     </div>
-  )
+  );
 }

--- a/M8MED/src/pages/EditComplexity.tsx
+++ b/M8MED/src/pages/EditComplexity.tsx
@@ -1,35 +1,37 @@
-import { useM8Store } from '../store/useM8Store'
-import { useState } from 'react'
+import { useM8Store } from '../store/useM8Store';
+import { useState } from 'react';
 
 export default function EditComplexity() {
   // Obtenemos los valores de complejidad actuales
-  const complejidadValores = useM8Store((state) => state.complejidadValores)
-  const editarComplejidad = useM8Store((state) => state.editarComplejidad)
+  const complejidadValores = useM8Store((state) => state.complejidadValores);
+  const editarComplejidad = useM8Store((state) => state.editarComplejidad);
 
   // Convertimos a array para renderizar y mantener valores locales hasta guardar
   const [valoresLocales, setValoresLocales] = useState(() => {
-    const obj: { [nivel: number]: number } = {}
+    const obj: { [nivel: number]: number } = {};
     for (let i = 1; i <= 10; i++) {
-      obj[i] = complejidadValores[i] ?? 0
+      obj[i] = complejidadValores[i] ?? 0;
     }
-    return obj
-  })
+    return obj;
+  });
 
   const handleChange = (nivel: number, valor: number) => {
-    setValoresLocales((prev) => ({ ...prev, [nivel]: valor }))
-  }
+    setValoresLocales((prev) => ({ ...prev, [nivel]: valor }));
+  };
 
   const handleSave = () => {
     Object.entries(valoresLocales).forEach(([nivelStr, valor]) => {
-      const nivel = parseInt(nivelStr)
-      editarComplejidad(nivel, Number(valor))
-    })
-    alert('Valores de complejidad actualizados')
-  }
+      const nivel = parseInt(nivelStr);
+      editarComplejidad(nivel, Number(valor));
+    });
+    alert('Valores de complejidad actualizados');
+  };
 
   return (
     <div className="p-6 max-w-lg mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Gestión de niveles de complejidad</h1>
+      <h1 className="text-2xl font-bold mb-4">
+        Gestión de niveles de complejidad
+      </h1>
       <table className="min-w-full text-sm bg-white rounded shadow">
         <thead className="bg-gray-100 text-gray-700 text-left">
           <tr>
@@ -45,9 +47,7 @@ export default function EditComplexity() {
                 <input
                   type="number"
                   value={valoresLocales[nivel]}
-                  onChange={(e) =>
-                    handleChange(nivel, Number(e.target.value))
-                  }
+                  onChange={(e) => handleChange(nivel, Number(e.target.value))}
                   className="input w-full"
                   min={0}
                 />
@@ -63,5 +63,5 @@ export default function EditComplexity() {
         Guardar cambios
       </button>
     </div>
-  )
+  );
 }

--- a/M8MED/src/pages/EditarPaciente.tsx
+++ b/M8MED/src/pages/EditarPaciente.tsx
@@ -1,0 +1,54 @@
+import { useNavigate, useParams } from 'react-router-dom'
+import Navbar from '../components/Navbar'
+import FormPaciente from '../components/FormPaciente'
+import { usePacienteStore } from '../store/usePacienteStore'
+
+export default function EditarPaciente() {
+  const navigate = useNavigate()
+  const { id } = useParams()
+  const paciente = usePacienteStore((s) => s.pacientes.find((p) => p.id === id))
+  const eliminarPaciente = usePacienteStore((s) => s.eliminarPaciente)
+
+  const handleFinish = () => {
+    navigate('/pacientes')
+  }
+
+  if (!paciente) {
+    return (
+      <>
+        <Navbar />
+        <div className="p-6 pt-20">
+          <p>Paciente no encontrado.</p>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Navbar />
+      <div className="max-w-2xl mx-auto p-6 pt-20">
+        <div className="flex justify-between items-center mb-4">
+          <h1 className="text-2xl font-bold">Editar Paciente</h1>
+          <button
+            onClick={() => navigate('/pacientes')}
+            className="text-blue-600 hover:underline"
+          >
+            ← Volver
+          </button>
+        </div>
+        <FormPaciente paciente={paciente} onFinish={handleFinish} />
+        <button
+          onClick={() => {
+            eliminarPaciente(paciente.id)
+            navigate('/pacientes')
+          }}
+          className="text-red-600 hover:underline mt-4"
+        >
+          Eliminar paciente
+        </button>
+      </div>
+    </>
+  )
+}
+

--- a/M8MED/src/pages/EditarPaciente.tsx
+++ b/M8MED/src/pages/EditarPaciente.tsx
@@ -17,9 +17,16 @@ export default function EditarPaciente() {
     return (
       <>
         <Navbar />
-        <div className="p-6 pt-20">
-          <p>Paciente no encontrado.</p>
-        </div>
+        <header className="bg-white shadow">
+          <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+            <h1 className="text-3xl font-bold tracking-tight text-gray-900">Editar Paciente</h1>
+          </div>
+        </header>
+        <main>
+          <div className="mx-auto max-w-2xl px-4 py-6 sm:px-6 lg:px-8">
+            <p>Paciente no encontrado.</p>
+          </div>
+        </main>
       </>
     )
   }
@@ -27,27 +34,33 @@ export default function EditarPaciente() {
   return (
     <>
       <Navbar />
-      <div className="max-w-2xl mx-auto p-6 pt-20">
-        <div className="flex justify-between items-center mb-4">
-          <h1 className="text-2xl font-bold">Editar Paciente</h1>
+      <header className="bg-white shadow">
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">Editar Paciente</h1>
+        </div>
+      </header>
+      <main>
+        <div className="mx-auto max-w-2xl px-4 py-6 sm:px-6 lg:px-8">
+          <div className="flex justify-end mb-4">
+            <button
+              onClick={() => navigate('/pacientes')}
+              className="text-blue-600 hover:underline"
+            >
+              ← Volver
+            </button>
+          </div>
+          <FormPaciente paciente={paciente} onFinish={handleFinish} />
           <button
-            onClick={() => navigate('/pacientes')}
-            className="text-blue-600 hover:underline"
+            onClick={() => {
+              eliminarPaciente(paciente.id)
+              navigate('/pacientes')
+            }}
+            className="text-red-600 hover:underline mt-4"
           >
-            ← Volver
+            Eliminar paciente
           </button>
         </div>
-        <FormPaciente paciente={paciente} onFinish={handleFinish} />
-        <button
-          onClick={() => {
-            eliminarPaciente(paciente.id)
-            navigate('/pacientes')
-          }}
-          className="text-red-600 hover:underline mt-4"
-        >
-          Eliminar paciente
-        </button>
-      </div>
+      </main>
     </>
   )
 }

--- a/M8MED/src/pages/EditarPaciente.tsx
+++ b/M8MED/src/pages/EditarPaciente.tsx
@@ -1,17 +1,19 @@
-import { useNavigate, useParams } from 'react-router-dom'
-import Navbar from '../components/Navbar'
-import FormPaciente from '../components/FormPaciente'
-import { usePacienteStore } from '../store/usePacienteStore'
+import { useNavigate, useParams } from 'react-router-dom';
+import Navbar from '../components/Navbar';
+import FormPaciente from '../components/FormPaciente';
+import { usePacienteStore } from '../store/usePacienteStore';
 
 export default function EditarPaciente() {
-  const navigate = useNavigate()
-  const { id } = useParams()
-  const paciente = usePacienteStore((s) => s.pacientes.find((p) => p.id === id))
-  const eliminarPaciente = usePacienteStore((s) => s.eliminarPaciente)
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const paciente = usePacienteStore((s) =>
+    s.pacientes.find((p) => p.id === id),
+  );
+  const eliminarPaciente = usePacienteStore((s) => s.eliminarPaciente);
 
   const handleFinish = () => {
-    navigate('/pacientes')
-  }
+    navigate('/pacientes');
+  };
 
   if (!paciente) {
     return (
@@ -19,7 +21,9 @@ export default function EditarPaciente() {
         <Navbar />
         <header className="bg-white shadow">
           <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-            <h1 className="text-3xl font-bold tracking-tight text-gray-900">Editar Paciente</h1>
+            <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+              Editar Paciente
+            </h1>
           </div>
         </header>
         <main>
@@ -28,7 +32,7 @@ export default function EditarPaciente() {
           </div>
         </main>
       </>
-    )
+    );
   }
 
   return (
@@ -36,7 +40,9 @@ export default function EditarPaciente() {
       <Navbar />
       <header className="bg-white shadow">
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-          <h1 className="text-3xl font-bold tracking-tight text-gray-900">Editar Paciente</h1>
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+            Editar Paciente
+          </h1>
         </div>
       </header>
       <main>
@@ -52,8 +58,8 @@ export default function EditarPaciente() {
           <FormPaciente paciente={paciente} onFinish={handleFinish} />
           <button
             onClick={() => {
-              eliminarPaciente(paciente.id)
-              navigate('/pacientes')
+              eliminarPaciente(paciente.id);
+              navigate('/pacientes');
             }}
             className="text-red-600 hover:underline mt-4"
           >
@@ -62,6 +68,5 @@ export default function EditarPaciente() {
         </div>
       </main>
     </>
-  )
+  );
 }
-

--- a/M8MED/src/pages/GeneralSummary.tsx
+++ b/M8MED/src/pages/GeneralSummary.tsx
@@ -1,84 +1,82 @@
-import { useM8Store, type Surgery } from '../store/useM8Store'
-import { useState, useMemo } from 'react'
-import FormSurgery from '../components/FormSurgery'
-import Modal from '../components/Modal'
-import { meses, ultimosAnios } from '../lib/date'
+import { useM8Store, type Surgery } from '../store/useM8Store';
+import { useState, useMemo } from 'react';
+import FormSurgery from '../components/FormSurgery';
+import Modal from '../components/Modal';
+import { meses, ultimosAnios } from '../lib/date';
 
 export default function GeneralSummary() {
   // Datos de la store
-  const doctores = useM8Store((state) => state.doctores)
-  const cirugias = useM8Store((state) => state.cirugias)
-  const eliminarCirugia = useM8Store((s) => s.eliminarCirugia)
+  const doctores = useM8Store((state) => state.doctores);
+  const cirugias = useM8Store((state) => state.cirugias);
+  const eliminarCirugia = useM8Store((s) => s.eliminarCirugia);
 
-  const [showForm, setShowForm] = useState(false)
-  const [editSurgery, setEditSurgery] = useState<Surgery | null>(null)
+  const [showForm, setShowForm] = useState(false);
+  const [editSurgery, setEditSurgery] = useState<Surgery | null>(null);
 
   // Filtros de mes, año y médico
-  const ahora = new Date()
-  const [mesFiltro, setMesFiltro] = useState<number>(ahora.getMonth() + 1)
-  const [anioFiltro, setAnioFiltro] = useState<number>(ahora.getFullYear())
-  const [medicoFiltro, setMedicoFiltro] = useState<string>('') // '' significa todos
+  const ahora = new Date();
+  const [mesFiltro, setMesFiltro] = useState<number>(ahora.getMonth() + 1);
+  const [anioFiltro, setAnioFiltro] = useState<number>(ahora.getFullYear());
+  const [medicoFiltro, setMedicoFiltro] = useState<string>(''); // '' significa todos
 
   // Mapeo de IDs a nombres de médicos
   const doctorNames = useMemo(() => {
-    const map: Record<string, string> = {}
+    const map: Record<string, string> = {};
     doctores.forEach((d) => {
-      map[d.id] = `${d.nombre} ${d.apellido}`
-    })
-    return map
-  }, [doctores])
+      map[d.id] = `${d.nombre} ${d.apellido}`;
+    });
+    return map;
+  }, [doctores]);
 
   // Filtrar cirugías por mes, año y (opcional) médico participante
   const cirugiasFiltradas = useMemo(() => {
     return cirugias.filter((c) => {
-      const fecha = new Date(`${c.fecha}T${c.hora}`)
+      const fecha = new Date(`${c.fecha}T${c.hora}`);
       const coincideFecha =
         fecha.getMonth() + 1 === mesFiltro &&
-        fecha.getFullYear() === anioFiltro
+        fecha.getFullYear() === anioFiltro;
       const coincideMedico =
         !medicoFiltro ||
         c.doctorId === medicoFiltro ||
-        c.ayudantes.includes(medicoFiltro)
-      return coincideFecha && coincideMedico
-    })
-  }, [cirugias, mesFiltro, anioFiltro, medicoFiltro])
+        c.ayudantes.includes(medicoFiltro);
+      return coincideFecha && coincideMedico;
+    });
+  }, [cirugias, mesFiltro, anioFiltro, medicoFiltro]);
 
-  const anios = useMemo(() => ultimosAnios(), [])
+  const anios = useMemo(() => ultimosAnios(), []);
 
   // Exportar a CSV detallado
   const exportCSV = () => {
     let csv =
-      'Fecha,Hora,Paciente,Diagnóstico,Tratamiento,Complejidad,Nivel valor,Valor base,Participantes,Monto por participante\n'
+      'Fecha,Hora,Paciente,Diagnóstico,Tratamiento,Complejidad,Nivel valor,Valor base,Participantes,Monto por participante\n';
     cirugiasFiltradas.forEach((c) => {
       const participantes = [c.doctorId, ...c.ayudantes]
         .map((id) => doctorNames[id] ?? id)
-        .join(' / ')
-      const partes = 1 + c.ayudantes.length
-      const pago = c.valorBase / partes
-      csv += `"${c.fecha}","${c.hora}","${c.paciente.nombre} (${c.paciente.dni})","${c.diagnostico}","${c.tipo}",${c.complejidad},${c.valorBase},"${participantes}",${pago}\n`
-    })
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement('a')
-    link.href = url
+        .join(' / ');
+      const partes = 1 + c.ayudantes.length;
+      const pago = c.valorBase / partes;
+      csv += `"${c.fecha}","${c.hora}","${c.paciente.nombre} (${c.paciente.dni})","${c.diagnostico}","${c.tipo}",${c.complejidad},${c.valorBase},"${participantes}",${pago}\n`;
+    });
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
     link.setAttribute(
       'download',
-      `resumen_detalle_${mesFiltro}_${anioFiltro}.csv`
-    )
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-  }
+      `resumen_detalle_${mesFiltro}_${anioFiltro}.csv`,
+    );
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
 
   return (
     <div className="p-6 max-w-full mx-auto">
-      <h1 className="text-2xl font-bold mb-4">
-        Resumen general de cirugías
-      </h1>
+      <h1 className="text-2xl font-bold mb-4">Resumen general de cirugías</h1>
 
       {/* Filtros de mes, año y médico */}
       <div className="flex flex-wrap gap-4 mb-4">
-      <div>
+        <div>
           <label className="mr-2 font-medium">Mes:</label>
           <select
             value={mesFiltro}
@@ -126,8 +124,8 @@ export default function GeneralSummary() {
       <div className="mb-4">
         <button
           onClick={() => {
-            setEditSurgery(null)
-            setShowForm(true)
+            setEditSurgery(null);
+            setShowForm(true);
           }}
           className="btn"
         >
@@ -156,9 +154,9 @@ export default function GeneralSummary() {
             {cirugiasFiltradas.map((c) => {
               const participantes = [c.doctorId, ...c.ayudantes]
                 .map((id) => doctorNames[id] ?? id)
-                .join(' / ')
-              const partes = 1 + c.ayudantes.length
-              const pago = c.valorBase / partes
+                .join(' / ');
+              const partes = 1 + c.ayudantes.length;
+              const pago = c.valorBase / partes;
               return (
                 <tr key={c.id} className="border-b hover:bg-gray-50">
                   <td className="px-4 py-2">{c.fecha}</td>
@@ -175,8 +173,8 @@ export default function GeneralSummary() {
                   <td className="px-4 py-2 space-x-2">
                     <button
                       onClick={() => {
-                        setEditSurgery(c)
-                        setShowForm(true)
+                        setEditSurgery(c);
+                        setShowForm(true);
                       }}
                       className="text-sky-600 hover:underline"
                     >
@@ -190,7 +188,7 @@ export default function GeneralSummary() {
                     </button>
                   </td>
                 </tr>
-              )
+              );
             })}
           </tbody>
         </table>
@@ -207,12 +205,11 @@ export default function GeneralSummary() {
         <FormSurgery
           surgery={editSurgery ?? undefined}
           onFinish={() => {
-            setShowForm(false)
-            setEditSurgery(null)
+            setShowForm(false);
+            setEditSurgery(null);
           }}
         />
       </Modal>
     </div>
-  )
+  );
 }
-

--- a/M8MED/src/pages/Landing.tsx
+++ b/M8MED/src/pages/Landing.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-
+import fotoLanding from "../assets/fotolanding.jpg";
 export default function Landing() {
   return (
     <div className="scroll-smooth">
@@ -49,7 +49,7 @@ export default function Landing() {
             </Link>
           </div>
           <img
-            src="https://images.unsplash.com/photo-1580281658629-3a2b9232cb29?auto=format&fit=crop&w=600&q=60"
+            src={fotoLanding}
             alt="App médica"
             className="md:w-1/2 rounded-xl shadow-lg"
           />

--- a/M8MED/src/pages/Landing.tsx
+++ b/M8MED/src/pages/Landing.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router-dom';
 
 export default function Landing() {
   return (
@@ -7,24 +7,46 @@ export default function Landing() {
         <nav className="max-w-7xl mx-auto flex items-center justify-between p-4">
           <span className="text-2xl font-bold text-sky-600">MedM8</span>
           <div className="hidden md:flex gap-8 text-sm">
-            <a href="#inicio" className="hover:text-sky-600">Inicio</a>
-            <a href="#funcionalidades" className="hover:text-sky-600">Funcionalidades</a>
-            <a href="#beneficios" className="hover:text-sky-600">Beneficios</a>
-            <a href="#contacto" className="hover:text-sky-600">Contacto</a>
+            <a href="#inicio" className="hover:text-sky-600">
+              Inicio
+            </a>
+            <a href="#funcionalidades" className="hover:text-sky-600">
+              Funcionalidades
+            </a>
+            <a href="#beneficios" className="hover:text-sky-600">
+              Beneficios
+            </a>
+            <a href="#contacto" className="hover:text-sky-600">
+              Contacto
+            </a>
           </div>
           <div className="flex gap-4">
-            <Link to="/login" className="btn text-sm">Iniciar sesión</Link>
-            <a href="#contacto" className="btn text-sm hidden md:inline-block">Probar ahora</a>
+            <Link to="/login" className="btn text-sm">
+              Iniciar sesión
+            </Link>
+            <a href="#contacto" className="btn text-sm hidden md:inline-block">
+              Probar ahora
+            </a>
           </div>
         </nav>
       </header>
 
       <main className="pt-20">
-        <section id="inicio" className="max-w-7xl mx-auto flex flex-col md:flex-row items-center gap-8 px-4 py-16">
+        <section
+          id="inicio"
+          className="max-w-7xl mx-auto flex flex-col md:flex-row items-center gap-8 px-4 py-16"
+        >
           <div className="md:w-1/2 space-y-6 text-center md:text-left">
-            <h1 className="text-4xl md:text-5xl font-bold">Simplifica tu gestión médica</h1>
-            <p className="text-lg text-gray-700">MedM8 alivia la carga administrativa y agiliza la comunicación médico-paciente</p>
-            <Link to="/login" className="btn inline-block">Empieza gratis</Link>
+            <h1 className="text-4xl md:text-5xl font-bold">
+              Simplifica tu gestión médica
+            </h1>
+            <p className="text-lg text-gray-700">
+              MedM8 alivia la carga administrativa y agiliza la comunicación
+              médico-paciente
+            </p>
+            <Link to="/login" className="btn inline-block">
+              Empieza gratis
+            </Link>
           </div>
           <img
             src="https://images.unsplash.com/photo-1580281658629-3a2b9232cb29?auto=format&fit=crop&w=600&q=60"
@@ -34,11 +56,15 @@ export default function Landing() {
         </section>
 
         <section id="funcionalidades" className="bg-gray-50 py-16">
-          <h2 className="text-3xl font-semibold text-center mb-10">Funcionalidades</h2>
+          <h2 className="text-3xl font-semibold text-center mb-10">
+            Funcionalidades
+          </h2>
           <div className="max-w-5xl mx-auto grid gap-6 md:grid-cols-4 px-4">
             <div className="card text-center transition-transform hover:scale-105">
               <span className="text-4xl">📋</span>
-              <h3 className="font-medium mt-2">Gestión de pacientes y turnos</h3>
+              <h3 className="font-medium mt-2">
+                Gestión de pacientes y turnos
+              </h3>
             </div>
             <div className="card text-center transition-transform hover:scale-105">
               <span className="text-4xl">⏰</span>
@@ -46,7 +72,9 @@ export default function Landing() {
             </div>
             <div className="card text-center transition-transform hover:scale-105">
               <span className="text-4xl">💵</span>
-              <h3 className="font-medium mt-2">Generación de sueldos médicos</h3>
+              <h3 className="font-medium mt-2">
+                Generación de sueldos médicos
+              </h3>
             </div>
             <div className="card text-center transition-transform hover:scale-105">
               <span className="text-4xl">💊</span>
@@ -56,25 +84,37 @@ export default function Landing() {
         </section>
 
         <section id="beneficios" className="py-16">
-          <h2 className="text-3xl font-semibold text-center mb-6">Beneficios</h2>
+          <h2 className="text-3xl font-semibold text-center mb-6">
+            Beneficios
+          </h2>
           <p className="max-w-3xl mx-auto text-center text-lg text-gray-700">
-            Aumenta la productividad de tu equipo, ahorra tiempo en tareas administrativas y mejora la comunicación con tus pacientes mediante recordatorios y recetas digitales.
+            Aumenta la productividad de tu equipo, ahorra tiempo en tareas
+            administrativas y mejora la comunicación con tus pacientes mediante
+            recordatorios y recetas digitales.
           </p>
         </section>
 
         <section id="testimonios" className="bg-gray-50 py-16">
-          <h2 className="text-3xl font-semibold text-center mb-10">Testimonios</h2>
+          <h2 className="text-3xl font-semibold text-center mb-10">
+            Testimonios
+          </h2>
           <div className="max-w-5xl mx-auto grid gap-6 md:grid-cols-3 px-4">
             <div className="card p-6 text-center">
-              <p className="italic">"MedM8 redujo a la mitad mi tiempo de gestión de turnos"</p>
+              <p className="italic">
+                "MedM8 redujo a la mitad mi tiempo de gestión de turnos"
+              </p>
               <span className="mt-4 font-medium block">Dr. Juan Pérez</span>
             </div>
             <div className="card p-6 text-center">
-              <p className="italic">"Ahora me comunico con mis pacientes de forma instantánea"</p>
+              <p className="italic">
+                "Ahora me comunico con mis pacientes de forma instantánea"
+              </p>
               <span className="mt-4 font-medium block">Dra. Ana Gómez</span>
             </div>
             <div className="card p-6 text-center">
-              <p className="italic">"La generación automática de sueldos es una maravilla"</p>
+              <p className="italic">
+                "La generación automática de sueldos es una maravilla"
+              </p>
               <span className="mt-4 font-medium block">Dr. Carlos López</span>
             </div>
           </div>
@@ -86,7 +126,9 @@ export default function Landing() {
             <input type="text" placeholder="Nombre" className="input" />
             <input type="email" placeholder="Email" className="input" />
             <textarea placeholder="Mensaje" rows={4} className="input" />
-            <button type="submit" className="btn w-full">Enviar</button>
+            <button type="submit" className="btn w-full">
+              Enviar
+            </button>
           </form>
         </section>
       </main>
@@ -95,13 +137,18 @@ export default function Landing() {
         <div className="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center px-4 gap-4">
           <span>&copy; {new Date().getFullYear()} MedM8</span>
           <div className="space-x-4">
-            <a href="#" className="hover:underline">Términos</a>
-            <a href="#" className="hover:underline">Privacidad</a>
-            <a href="#" className="hover:underline">Twitter</a>
+            <a href="#" className="hover:underline">
+              Términos
+            </a>
+            <a href="#" className="hover:underline">
+              Privacidad
+            </a>
+            <a href="#" className="hover:underline">
+              Twitter
+            </a>
           </div>
         </div>
       </footer>
     </div>
-  )
+  );
 }
-

--- a/M8MED/src/pages/Login.tsx
+++ b/M8MED/src/pages/Login.tsx
@@ -1,19 +1,22 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useUserStore } from '../store/useUserStore'
+import { useM8Store } from '../store/useM8Store'
 
 export default function Login() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const setUser = useUserStore((state) => state.setUser)
+  const doctores = useM8Store((s) => s.doctores)
   const navigate = useNavigate()
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
 
-    // Comprobamos credenciales fijas
+    // Admin fijo
     if (email === 'admin@test.com' && password === '1234') {
       setUser({
+        id: 'admin',
         email,
         rol: 'admin',
         nombre: 'Admin',
@@ -22,14 +25,22 @@ export default function Login() {
         foto: 'https://placehold.co/64',
       })
       navigate('/dashboard-admin')
-    } else if (email === 'medico@test.com' && password === '1234') {
+      return
+    }
+
+    // Buscar médico con esas credenciales
+    const doctor = doctores.find(
+      (d) => d.email === email && d.password === password
+    )
+    if (doctor) {
       setUser({
-        email,
+        id: doctor.id,
+        email: doctor.email,
         rol: 'medico',
-        nombre: 'Juan',
-        apellido: 'Pérez',
-        password,
-        foto: 'https://placehold.co/64',
+        nombre: doctor.nombre,
+        apellido: doctor.apellido,
+        password: doctor.password,
+        foto: doctor.foto,
       })
       navigate('/dashboard-medico')
     } else {

--- a/M8MED/src/pages/Login.tsx
+++ b/M8MED/src/pages/Login.tsx
@@ -13,10 +13,24 @@ export default function Login() {
 
     // Comprobamos credenciales fijas
     if (email === 'admin@test.com' && password === '1234') {
-      setUser({ email, rol: 'admin' })
+      setUser({
+        email,
+        rol: 'admin',
+        nombre: 'Admin',
+        apellido: 'Principal',
+        password,
+        foto: 'https://placehold.co/64',
+      })
       navigate('/dashboard-admin')
     } else if (email === 'medico@test.com' && password === '1234') {
-      setUser({ email, rol: 'medico' })
+      setUser({
+        email,
+        rol: 'medico',
+        nombre: 'Juan',
+        apellido: 'Pérez',
+        password,
+        foto: 'https://placehold.co/64',
+      })
       navigate('/dashboard-medico')
     } else {
       alert('Credenciales incorrectas')

--- a/M8MED/src/pages/Login.tsx
+++ b/M8MED/src/pages/Login.tsx
@@ -1,17 +1,17 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { useUserStore } from '../store/useUserStore'
-import { useM8Store } from '../store/useM8Store'
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useUserStore } from '../store/useUserStore';
+import { useM8Store } from '../store/useM8Store';
 
 export default function Login() {
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const setUser = useUserStore((state) => state.setUser)
-  const doctores = useM8Store((s) => s.doctores)
-  const navigate = useNavigate()
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const setUser = useUserStore((state) => state.setUser);
+  const doctores = useM8Store((s) => s.doctores);
+  const navigate = useNavigate();
 
   const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
+    e.preventDefault();
 
     // Admin fijo
     if (email === 'admin@test.com' && password === '1234') {
@@ -23,15 +23,15 @@ export default function Login() {
         apellido: 'Principal',
         password,
         foto: 'https://placehold.co/64',
-      })
-      navigate('/dashboard-admin')
-      return
+      });
+      navigate('/dashboard-admin');
+      return;
     }
 
     // Buscar médico con esas credenciales
     const doctor = doctores.find(
-      (d) => d.email === email && d.password === password
-    )
+      (d) => d.email === email && d.password === password,
+    );
     if (doctor) {
       setUser({
         id: doctor.id,
@@ -41,17 +41,19 @@ export default function Login() {
         apellido: doctor.apellido,
         password: doctor.password,
         foto: doctor.foto,
-      })
-      navigate('/dashboard-medico')
+      });
+      navigate('/dashboard-medico');
     } else {
-      alert('Credenciales incorrectas')
+      alert('Credenciales incorrectas');
     }
-  }
+  };
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-blue-50 to-blue-200">
       <div className="w-full max-w-md p-8 bg-white rounded-xl shadow-lg">
-        <h1 className="text-3xl font-semibold mb-6 text-center">Iniciar sesión</h1>
+        <h1 className="text-3xl font-semibold mb-6 text-center">
+          Iniciar sesión
+        </h1>
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>
             <label className="block text-sm font-medium">Email</label>
@@ -81,5 +83,5 @@ export default function Login() {
         </form>
       </div>
     </div>
-  )
+  );
 }

--- a/M8MED/src/pages/NewSurgery.tsx
+++ b/M8MED/src/pages/NewSurgery.tsx
@@ -1,9 +1,9 @@
-import { useNavigate } from 'react-router-dom'
-import Navbar from '../components/Navbar'
-import FormSurgery from '../components/FormSurgery'
+import { useNavigate } from 'react-router-dom';
+import Navbar from '../components/Navbar';
+import FormSurgery from '../components/FormSurgery';
 
 export default function NewSurgery() {
-  const navigate = useNavigate()
+  const navigate = useNavigate();
   return (
     <>
       <Navbar />
@@ -12,5 +12,5 @@ export default function NewSurgery() {
         <FormSurgery onFinish={() => navigate('/dashboard-admin')} />
       </div>
     </>
-  )
+  );
 }

--- a/M8MED/src/pages/Pacientes.tsx
+++ b/M8MED/src/pages/Pacientes.tsx
@@ -1,10 +1,12 @@
 import { usePacienteStore } from '../store/usePacienteStore'
+import { useM8Store } from '../store/useM8Store'
 import Navbar from '../components/Navbar'
 import { Link } from 'react-router-dom'
 
 export default function Pacientes() {
   const pacientes = usePacienteStore((state) => state.pacientes)
   const eliminarPaciente = usePacienteStore((s) => s.eliminarPaciente)
+  const doctores = useM8Store((s) => s.doctores)
 
   return (
     <>
@@ -25,6 +27,7 @@ export default function Pacientes() {
                 <th className="px-4 py-2">Teléfono</th>
                 <th className="px-4 py-2">Email</th>
                 <th className="px-4 py-2">Género</th>
+                <th className="px-4 py-2">Médico</th>
                 <th className="px-4 py-2">Acciones</th>
               </tr>
             </thead>
@@ -37,6 +40,10 @@ export default function Pacientes() {
                   <td className="px-4 py-2">{paciente.telefono}</td>
                   <td className="px-4 py-2">{paciente.email}</td>
                   <td className="px-4 py-2 capitalize">{paciente.genero}</td>
+                  <td className="px-4 py-2">
+                    {doctores.find((d) => d.id === paciente.doctorId)?.nombre}{' '}
+                    {doctores.find((d) => d.id === paciente.doctorId)?.apellido}
+                  </td>
                   <td className="px-4 py-2 space-x-2">
                     <Link
                       to={`/pacientes/editar/${paciente.id}`}

--- a/M8MED/src/pages/Pacientes.tsx
+++ b/M8MED/src/pages/Pacientes.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { usePacienteStore } from '../store/usePacienteStore'
 import { useM8Store } from '../store/useM8Store'
 import Navbar from '../components/Navbar'
@@ -7,6 +8,14 @@ export default function Pacientes() {
   const pacientes = usePacienteStore((state) => state.pacientes)
   const eliminarPaciente = usePacienteStore((s) => s.eliminarPaciente)
   const doctores = useM8Store((s) => s.doctores)
+
+  const doctorMap = useMemo(() => {
+    const map: Record<string, string> = {}
+    doctores.forEach((d) => {
+      map[d.id] = `${d.nombre} ${d.apellido}`
+    })
+    return map
+  }, [doctores])
 
   return (
     <>
@@ -40,10 +49,7 @@ export default function Pacientes() {
                   <td className="px-4 py-2">{paciente.telefono}</td>
                   <td className="px-4 py-2">{paciente.email}</td>
                   <td className="px-4 py-2 capitalize">{paciente.genero}</td>
-                  <td className="px-4 py-2">
-                    {doctores.find((d) => d.id === paciente.doctorId)?.nombre}{' '}
-                    {doctores.find((d) => d.id === paciente.doctorId)?.apellido}
-                  </td>
+                  <td className="px-4 py-2">{doctorMap[paciente.doctorId]}</td>
                   <td className="px-4 py-2 space-x-2">
                     <Link
                       to={`/pacientes/editar/${paciente.id}`}

--- a/M8MED/src/pages/Pacientes.tsx
+++ b/M8MED/src/pages/Pacientes.tsx
@@ -20,11 +20,16 @@ export default function Pacientes() {
   return (
     <>
       <Navbar />
-      <div className="max-w-6xl mx-auto p-6 pt-20">
-        <div className="flex justify-between items-center mb-6">
-          <h1 className="text-2xl font-bold">Pacientes</h1>
-          <Link to="/agregar-paciente" className="btn">+ Agregar Paciente</Link>
+      <header className="bg-white shadow">
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">Pacientes</h1>
         </div>
+      </header>
+      <main>
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+          <div className="flex justify-end mb-4">
+            <Link to="/agregar-paciente" className="btn">+ Agregar Paciente</Link>
+          </div>
 
         <div className="bg-white shadow rounded-lg overflow-x-auto">
           <table className="min-w-full text-sm">
@@ -69,7 +74,8 @@ export default function Pacientes() {
             </tbody>
           </table>
         </div>
-      </div>
+        </div>
+      </main>
     </>
   )
 }

--- a/M8MED/src/pages/Pacientes.tsx
+++ b/M8MED/src/pages/Pacientes.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 
 export default function Pacientes() {
   const pacientes = usePacienteStore((state) => state.pacientes)
+  const eliminarPaciente = usePacienteStore((s) => s.eliminarPaciente)
 
   return (
     <>
@@ -24,6 +25,7 @@ export default function Pacientes() {
                 <th className="px-4 py-2">Teléfono</th>
                 <th className="px-4 py-2">Email</th>
                 <th className="px-4 py-2">Género</th>
+                <th className="px-4 py-2">Acciones</th>
               </tr>
             </thead>
             <tbody>
@@ -35,6 +37,20 @@ export default function Pacientes() {
                   <td className="px-4 py-2">{paciente.telefono}</td>
                   <td className="px-4 py-2">{paciente.email}</td>
                   <td className="px-4 py-2 capitalize">{paciente.genero}</td>
+                  <td className="px-4 py-2 space-x-2">
+                    <Link
+                      to={`/pacientes/editar/${paciente.id}`}
+                      className="text-sky-600 hover:underline"
+                    >
+                      Editar
+                    </Link>
+                    <button
+                      onClick={() => eliminarPaciente(paciente.id)}
+                      className="text-red-600 hover:underline"
+                    >
+                      Eliminar
+                    </button>
+                  </td>
                 </tr>
               ))}
             </tbody>
@@ -44,3 +60,4 @@ export default function Pacientes() {
     </>
   )
 }
+

--- a/M8MED/src/pages/Pacientes.tsx
+++ b/M8MED/src/pages/Pacientes.tsx
@@ -1,82 +1,87 @@
-import { useMemo } from 'react'
-import { usePacienteStore } from '../store/usePacienteStore'
-import { useM8Store } from '../store/useM8Store'
-import Navbar from '../components/Navbar'
-import { Link } from 'react-router-dom'
+import { useMemo } from 'react';
+import { usePacienteStore } from '../store/usePacienteStore';
+import { useM8Store } from '../store/useM8Store';
+import Navbar from '../components/Navbar';
+import { Link } from 'react-router-dom';
 
 export default function Pacientes() {
-  const pacientes = usePacienteStore((state) => state.pacientes)
-  const eliminarPaciente = usePacienteStore((s) => s.eliminarPaciente)
-  const doctores = useM8Store((s) => s.doctores)
+  const pacientes = usePacienteStore((state) => state.pacientes);
+  const eliminarPaciente = usePacienteStore((s) => s.eliminarPaciente);
+  const doctores = useM8Store((s) => s.doctores);
 
   const doctorMap = useMemo(() => {
-    const map: Record<string, string> = {}
+    const map: Record<string, string> = {};
     doctores.forEach((d) => {
-      map[d.id] = `${d.nombre} ${d.apellido}`
-    })
-    return map
-  }, [doctores])
+      map[d.id] = `${d.nombre} ${d.apellido}`;
+    });
+    return map;
+  }, [doctores]);
 
   return (
     <>
       <Navbar />
       <header className="bg-white shadow">
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-          <h1 className="text-3xl font-bold tracking-tight text-gray-900">Pacientes</h1>
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+            Pacientes
+          </h1>
         </div>
       </header>
       <main>
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
           <div className="flex justify-end mb-4">
-            <Link to="/agregar-paciente" className="btn">+ Agregar Paciente</Link>
+            <Link to="/agregar-paciente" className="btn">
+              + Agregar Paciente
+            </Link>
           </div>
 
-        <div className="bg-white shadow rounded-lg overflow-x-auto">
-          <table className="min-w-full text-sm">
-            <thead className="bg-gray-100 text-gray-700 text-left">
-              <tr>
-                <th className="px-4 py-2">Nombre</th>
-                <th className="px-4 py-2">Apellido</th>
-                <th className="px-4 py-2">DNI</th>
-                <th className="px-4 py-2">Teléfono</th>
-                <th className="px-4 py-2">Email</th>
-                <th className="px-4 py-2">Género</th>
-                <th className="px-4 py-2">Médico</th>
-                <th className="px-4 py-2">Acciones</th>
-              </tr>
-            </thead>
-            <tbody>
-              {pacientes.map((paciente) => (
-                <tr key={paciente.id} className="border-b hover:bg-gray-50">
-                  <td className="px-4 py-2">{paciente.nombre}</td>
-                  <td className="px-4 py-2">{paciente.apellido}</td>
-                  <td className="px-4 py-2">{paciente.dni}</td>
-                  <td className="px-4 py-2">{paciente.telefono}</td>
-                  <td className="px-4 py-2">{paciente.email}</td>
-                  <td className="px-4 py-2 capitalize">{paciente.genero}</td>
-                  <td className="px-4 py-2">{doctorMap[paciente.doctorId]}</td>
-                  <td className="px-4 py-2 space-x-2">
-                    <Link
-                      to={`/pacientes/editar/${paciente.id}`}
-                      className="text-sky-600 hover:underline"
-                    >
-                      Editar
-                    </Link>
-                    <button
-                      onClick={() => eliminarPaciente(paciente.id)}
-                      className="text-red-600 hover:underline"
-                    >
-                      Eliminar
-                    </button>
-                  </td>
+          <div className="bg-white shadow rounded-lg overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-100 text-gray-700 text-left">
+                <tr>
+                  <th className="px-4 py-2">Nombre</th>
+                  <th className="px-4 py-2">Apellido</th>
+                  <th className="px-4 py-2">DNI</th>
+                  <th className="px-4 py-2">Teléfono</th>
+                  <th className="px-4 py-2">Email</th>
+                  <th className="px-4 py-2">Género</th>
+                  <th className="px-4 py-2">Médico</th>
+                  <th className="px-4 py-2">Acciones</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {pacientes.map((paciente) => (
+                  <tr key={paciente.id} className="border-b hover:bg-gray-50">
+                    <td className="px-4 py-2">{paciente.nombre}</td>
+                    <td className="px-4 py-2">{paciente.apellido}</td>
+                    <td className="px-4 py-2">{paciente.dni}</td>
+                    <td className="px-4 py-2">{paciente.telefono}</td>
+                    <td className="px-4 py-2">{paciente.email}</td>
+                    <td className="px-4 py-2 capitalize">{paciente.genero}</td>
+                    <td className="px-4 py-2">
+                      {doctorMap[paciente.doctorId]}
+                    </td>
+                    <td className="px-4 py-2 space-x-2">
+                      <Link
+                        to={`/pacientes/editar/${paciente.id}`}
+                        className="text-sky-600 hover:underline"
+                      >
+                        Editar
+                      </Link>
+                      <button
+                        onClick={() => eliminarPaciente(paciente.id)}
+                        className="text-red-600 hover:underline"
+                      >
+                        Eliminar
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       </main>
     </>
-  )
+  );
 }
-

--- a/M8MED/src/pages/PatientDetail.tsx
+++ b/M8MED/src/pages/PatientDetail.tsx
@@ -1,23 +1,23 @@
-import { usePacienteStore } from '../store/usePacienteStore'
-import { useState } from 'react'
+import { usePacienteStore } from '../store/usePacienteStore';
+import { useState } from 'react';
 
 type Props = {
-  pacienteId: string
-}
+  pacienteId: string;
+};
 
 export default function PatientDetail({ pacienteId }: Props) {
   const paciente = usePacienteStore((s) =>
-    s.pacientes.find((p) => p.id === pacienteId)
-  )
-  const [receta, setReceta] = useState('')
-  const [recordatorio, setRecordatorio] = useState('')
+    s.pacientes.find((p) => p.id === pacienteId),
+  );
+  const [receta, setReceta] = useState('');
+  const [recordatorio, setRecordatorio] = useState('');
 
   if (!paciente) {
     return (
       <div className="p-6">
         <p>Paciente no encontrado.</p>
       </div>
-    )
+    );
   }
 
   return (
@@ -51,8 +51,8 @@ export default function PatientDetail({ pacienteId }: Props) {
           />
           <button
             onClick={() => {
-              alert('Receta enviada')
-              setReceta('')
+              alert('Receta enviada');
+              setReceta('');
             }}
             className="btn mt-2"
           >
@@ -68,8 +68,8 @@ export default function PatientDetail({ pacienteId }: Props) {
           />
           <button
             onClick={() => {
-              alert('Recordatorio enviado')
-              setRecordatorio('')
+              alert('Recordatorio enviado');
+              setRecordatorio('');
             }}
             className="btn mt-2"
           >
@@ -78,5 +78,5 @@ export default function PatientDetail({ pacienteId }: Props) {
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/M8MED/src/pages/PerfilUsuario.tsx
+++ b/M8MED/src/pages/PerfilUsuario.tsx
@@ -1,15 +1,15 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import Navbar from '../components/Navbar'
-import { useUserStore } from '../store/useUserStore'
-import { useM8Store } from '../store/useM8Store'
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Navbar from '../components/Navbar';
+import { useUserStore } from '../store/useUserStore';
+import { useM8Store } from '../store/useM8Store';
 
 export default function PerfilUsuario() {
-  const user = useUserStore((s) => s.user)
-  const updateUser = useUserStore((s) => s.updateUser)
-  const editarDoctor = useM8Store((s) => s.editarDoctor)
-  const doctores = useM8Store((s) => s.doctores)
-  const navigate = useNavigate()
+  const user = useUserStore((s) => s.user);
+  const updateUser = useUserStore((s) => s.updateUser);
+  const editarDoctor = useM8Store((s) => s.editarDoctor);
+  const doctores = useM8Store((s) => s.doctores);
+  const navigate = useNavigate();
 
   const [form, setForm] = useState({
     nombre: user?.nombre ?? '',
@@ -17,20 +17,20 @@ export default function PerfilUsuario() {
     email: user?.email ?? '',
     password: user?.password ?? '',
     foto: user?.foto ?? '',
-  })
+  });
 
-  if (!user) return null
+  if (!user) return null;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target
-    setForm({ ...form, [name]: value })
-  }
+    const { name, value } = e.target;
+    setForm({ ...form, [name]: value });
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    updateUser(form)
+    e.preventDefault();
+    updateUser(form);
     if (user.rol === 'medico') {
-      const doctor = doctores.find((d) => d.id === user.id)
+      const doctor = doctores.find((d) => d.id === user.id);
       if (doctor) {
         editarDoctor(doctor.id, {
           ...doctor,
@@ -39,70 +39,72 @@ export default function PerfilUsuario() {
           email: form.email,
           password: form.password,
           foto: form.foto,
-        })
+        });
       }
     }
-    navigate(user.rol === 'admin' ? '/dashboard-admin' : '/dashboard-medico')
-  }
+    navigate(user.rol === 'admin' ? '/dashboard-admin' : '/dashboard-medico');
+  };
 
   return (
     <>
       <Navbar />
       <header className="bg-white shadow">
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-          <h1 className="text-3xl font-bold tracking-tight text-gray-900">Mi perfil</h1>
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+            Mi perfil
+          </h1>
         </div>
       </header>
       <main>
         <div className="mx-auto max-w-md px-4 py-6 sm:px-6 lg:px-8">
           <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            name="nombre"
-            value={form.nombre}
-            onChange={handleChange}
-            className="input"
-            placeholder="Nombre"
-            required
-          />
-          <input
-            name="apellido"
-            value={form.apellido}
-            onChange={handleChange}
-            className="input"
-            placeholder="Apellido"
-            required
-          />
-          <input
-            type="email"
-            name="email"
-            value={form.email}
-            onChange={handleChange}
-            className="input"
-            placeholder="Email"
-            required
-          />
-          <input
-            type="password"
-            name="password"
-            value={form.password}
-            onChange={handleChange}
-            className="input"
-            placeholder="Contraseña"
-            required
-          />
-          <input
-            name="foto"
-            value={form.foto}
-            onChange={handleChange}
-            className="input"
-            placeholder="URL de foto"
-          />
-          <button type="submit" className="btn w-full">
-            Guardar
-          </button>
-        </form>
+            <input
+              name="nombre"
+              value={form.nombre}
+              onChange={handleChange}
+              className="input"
+              placeholder="Nombre"
+              required
+            />
+            <input
+              name="apellido"
+              value={form.apellido}
+              onChange={handleChange}
+              className="input"
+              placeholder="Apellido"
+              required
+            />
+            <input
+              type="email"
+              name="email"
+              value={form.email}
+              onChange={handleChange}
+              className="input"
+              placeholder="Email"
+              required
+            />
+            <input
+              type="password"
+              name="password"
+              value={form.password}
+              onChange={handleChange}
+              className="input"
+              placeholder="Contraseña"
+              required
+            />
+            <input
+              name="foto"
+              value={form.foto}
+              onChange={handleChange}
+              className="input"
+              placeholder="URL de foto"
+            />
+            <button type="submit" className="btn w-full">
+              Guardar
+            </button>
+          </form>
         </div>
       </main>
     </>
-  )
+  );
 }

--- a/M8MED/src/pages/PerfilUsuario.tsx
+++ b/M8MED/src/pages/PerfilUsuario.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import Navbar from '../components/Navbar'
+import { useUserStore } from '../store/useUserStore'
+
+export default function PerfilUsuario() {
+  const user = useUserStore((s) => s.user)
+  const updateUser = useUserStore((s) => s.updateUser)
+  const navigate = useNavigate()
+
+  const [form, setForm] = useState({
+    nombre: user?.nombre ?? '',
+    apellido: user?.apellido ?? '',
+    email: user?.email ?? '',
+    password: user?.password ?? '',
+    foto: user?.foto ?? '',
+  })
+
+  if (!user) return null
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    setForm({ ...form, [name]: value })
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    updateUser(form)
+    navigate(user.rol === 'admin' ? '/dashboard-admin' : '/dashboard-medico')
+  }
+
+  return (
+    <>
+      <Navbar />
+      <div className="max-w-md mx-auto p-6 pt-20">
+        <h1 className="text-2xl font-bold mb-4">Mi perfil</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            name="nombre"
+            value={form.nombre}
+            onChange={handleChange}
+            className="input"
+            placeholder="Nombre"
+            required
+          />
+          <input
+            name="apellido"
+            value={form.apellido}
+            onChange={handleChange}
+            className="input"
+            placeholder="Apellido"
+            required
+          />
+          <input
+            type="email"
+            name="email"
+            value={form.email}
+            onChange={handleChange}
+            className="input"
+            placeholder="Email"
+            required
+          />
+          <input
+            type="password"
+            name="password"
+            value={form.password}
+            onChange={handleChange}
+            className="input"
+            placeholder="Contraseña"
+            required
+          />
+          <input
+            name="foto"
+            value={form.foto}
+            onChange={handleChange}
+            className="input"
+            placeholder="URL de foto"
+          />
+          <button type="submit" className="btn w-full">
+            Guardar
+          </button>
+        </form>
+      </div>
+    </>
+  )
+}

--- a/M8MED/src/pages/PerfilUsuario.tsx
+++ b/M8MED/src/pages/PerfilUsuario.tsx
@@ -2,10 +2,13 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import Navbar from '../components/Navbar'
 import { useUserStore } from '../store/useUserStore'
+import { useM8Store } from '../store/useM8Store'
 
 export default function PerfilUsuario() {
   const user = useUserStore((s) => s.user)
   const updateUser = useUserStore((s) => s.updateUser)
+  const editarDoctor = useM8Store((s) => s.editarDoctor)
+  const doctores = useM8Store((s) => s.doctores)
   const navigate = useNavigate()
 
   const [form, setForm] = useState({
@@ -26,6 +29,19 @@ export default function PerfilUsuario() {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     updateUser(form)
+    if (user.rol === 'medico') {
+      const doctor = doctores.find((d) => d.id === user.id)
+      if (doctor) {
+        editarDoctor(doctor.id, {
+          ...doctor,
+          nombre: form.nombre,
+          apellido: form.apellido,
+          email: form.email,
+          password: form.password,
+          foto: form.foto,
+        })
+      }
+    }
     navigate(user.rol === 'admin' ? '/dashboard-admin' : '/dashboard-medico')
   }
 

--- a/M8MED/src/pages/PerfilUsuario.tsx
+++ b/M8MED/src/pages/PerfilUsuario.tsx
@@ -48,9 +48,14 @@ export default function PerfilUsuario() {
   return (
     <>
       <Navbar />
-      <div className="max-w-md mx-auto p-6 pt-20">
-        <h1 className="text-2xl font-bold mb-4">Mi perfil</h1>
-        <form onSubmit={handleSubmit} className="space-y-4">
+      <header className="bg-white shadow">
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">Mi perfil</h1>
+        </div>
+      </header>
+      <main>
+        <div className="mx-auto max-w-md px-4 py-6 sm:px-6 lg:px-8">
+          <form onSubmit={handleSubmit} className="space-y-4">
           <input
             name="nombre"
             value={form.nombre}
@@ -96,7 +101,8 @@ export default function PerfilUsuario() {
             Guardar
           </button>
         </form>
-      </div>
+        </div>
+      </main>
     </>
   )
 }

--- a/M8MED/src/pages/Summary.tsx
+++ b/M8MED/src/pages/Summary.tsx
@@ -1,75 +1,69 @@
-import { useM8Store } from '../store/useM8Store'
-import { useState, useMemo } from 'react'
-import { meses, ultimosAnios } from '../lib/date'
+import { useM8Store } from '../store/useM8Store';
+import { useState, useMemo } from 'react';
+import { meses, ultimosAnios } from '../lib/date';
 
 export default function Summary() {
   // Obtenemos doctores y cirugías desde la store
-  const doctores = useM8Store((state) => state.doctores)
-  const cirugias = useM8Store((state) => state.cirugias)
+  const doctores = useM8Store((state) => state.doctores);
+  const cirugias = useM8Store((state) => state.cirugias);
 
   // Estado para filtrar por mes y año
-  const ahora = new Date()
-  const [mesFiltro, setMesFiltro] = useState<number>(ahora.getMonth() + 1)
-  const [anioFiltro, setAnioFiltro] = useState<number>(ahora.getFullYear())
+  const ahora = new Date();
+  const [mesFiltro, setMesFiltro] = useState<number>(ahora.getMonth() + 1);
+  const [anioFiltro, setAnioFiltro] = useState<number>(ahora.getFullYear());
 
-  const anios = useMemo(() => ultimosAnios(), [])
+  const anios = useMemo(() => ultimosAnios(), []);
 
   // Filtramos todas las cirugías según mes y año seleccionados
   const cirugiasFiltradas = useMemo(() => {
     return cirugias.filter((c) => {
-      const fecha = new Date(`${c.fecha}T${c.hora}`)
+      const fecha = new Date(`${c.fecha}T${c.hora}`);
       return (
-        fecha.getMonth() + 1 === mesFiltro &&
-        fecha.getFullYear() === anioFiltro
-      )
-    })
-  }, [cirugias, mesFiltro, anioFiltro])
+        fecha.getMonth() + 1 === mesFiltro && fecha.getFullYear() === anioFiltro
+      );
+    });
+  }, [cirugias, mesFiltro, anioFiltro]);
 
   // Contador global de cirugías en el mes seleccionado
-  const totalCirugias = cirugiasFiltradas.length
+  const totalCirugias = cirugiasFiltradas.length;
 
   // Calculamos el resumen por médico (participa como cirujano principal o ayudante)
   const resumen = useMemo(() => {
     return doctores.map((doc) => {
       const cirugiasDoc = cirugiasFiltradas.filter(
-        (c) => c.doctorId === doc.id || c.ayudantes.includes(doc.id)
-      )
+        (c) => c.doctorId === doc.id || c.ayudantes.includes(doc.id),
+      );
       const total = cirugiasDoc.reduce((sum, c) => {
-        const partes = 1 + c.ayudantes.length
-        return sum + c.valorBase / partes
-      }, 0)
+        const partes = 1 + c.ayudantes.length;
+        return sum + c.valorBase / partes;
+      }, 0);
       return {
         doctor: doc,
         count: cirugiasDoc.length,
         total,
-      }
-    })
-  }, [doctores, cirugiasFiltradas])
+      };
+    });
+  }, [doctores, cirugiasFiltradas]);
 
   // Exportar a CSV
   const exportCSV = () => {
-    let csv = 'Nombre,Email,Especialidad,Cirugías,Total\n'
+    let csv = 'Nombre,Email,Especialidad,Cirugías,Total\n';
     resumen.forEach((fila) => {
-      csv += `"${fila.doctor.nombre} ${fila.doctor.apellido}","${fila.doctor.email}","${fila.doctor.especialidad}",${fila.count},${fila.total}\n`
-    })
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement('a')
-    link.href = url
-    link.setAttribute(
-      'download',
-      `resumen_${mesFiltro}_${anioFiltro}.csv`
-    )
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-  }
+      csv += `"${fila.doctor.nombre} ${fila.doctor.apellido}","${fila.doctor.email}","${fila.doctor.especialidad}",${fila.count},${fila.total}\n`;
+    });
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', `resumen_${mesFiltro}_${anioFiltro}.csv`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
 
   return (
     <div className="p-6 max-w-4xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">
-        Resumen mensual de cirugías
-      </h1>
+      <h1 className="text-2xl font-bold mb-4">Resumen mensual de cirugías</h1>
 
       {/* Selectores de mes y año */}
       <div className="flex flex-wrap gap-4 mb-4">
@@ -129,9 +123,7 @@ export default function Summary() {
                 <td className="px-4 py-2">{fila.doctor.email}</td>
                 <td className="px-4 py-2">{fila.doctor.especialidad}</td>
                 <td className="px-4 py-2 text-center">{fila.count}</td>
-                <td className="px-4 py-2">
-                  ${fila.total.toFixed(2)}
-                </td>
+                <td className="px-4 py-2">${fila.total.toFixed(2)}</td>
               </tr>
             ))}
           </tbody>
@@ -145,5 +137,5 @@ export default function Summary() {
         Exportar CSV
       </button>
     </div>
-  )
+  );
 }

--- a/M8MED/src/pages/Turnos.tsx
+++ b/M8MED/src/pages/Turnos.tsx
@@ -34,8 +34,10 @@ export default function Turnos() {
                 <tr>
                   <th className="px-4 py-2">Fecha</th>
                   <th className="px-4 py-2">Hora</th>
+                  <th className="px-4 py-2">Tipo</th>
                   <th className="px-4 py-2">Paciente</th>
                   <th className="px-4 py-2">Médico</th>
+                  <th className="px-4 py-2">Descripción</th>
                   <th className="px-4 py-2">Acciones</th>
                 </tr>
               </thead>
@@ -47,12 +49,14 @@ export default function Turnos() {
                     <tr key={t.id} className="border-b hover:bg-gray-50">
                       <td className="px-4 py-2">{t.fecha}</td>
                       <td className="px-4 py-2">{t.hora}</td>
+                      <td className="px-4 py-2 capitalize">{t.tipo}</td>
                       <td className="px-4 py-2">
                         {pac?.nombre} {pac?.apellido}
                       </td>
                       <td className="px-4 py-2">
                         {doc?.nombre} {doc?.apellido}
                       </td>
+                      <td className="px-4 py-2">{t.descripcion}</td>
                       <td className="px-4 py-2 space-x-2">
                         <button
                           onClick={() => setEditTurnoId(t.id)}

--- a/M8MED/src/pages/Turnos.tsx
+++ b/M8MED/src/pages/Turnos.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import Navbar from '../components/Navbar'
 import Modal from '../components/Modal'
 import FormTurno from '../components/FormTurno'
@@ -11,6 +11,22 @@ export default function Turnos() {
   const eliminarTurno = useTurnoStore((s) => s.eliminarTurno)
   const pacientes = usePacienteStore((s) => s.pacientes)
   const doctores = useM8Store((s) => s.doctores)
+
+  const pacienteMap = useMemo(() => {
+    const map: Record<string, string> = {}
+    pacientes.forEach((p) => {
+      map[p.id] = `${p.nombre} ${p.apellido}`
+    })
+    return map
+  }, [pacientes])
+
+  const doctorMap = useMemo(() => {
+    const map: Record<string, string> = {}
+    doctores.forEach((d) => {
+      map[d.id] = `${d.nombre} ${d.apellido}`
+    })
+    return map
+  }, [doctores])
 
   const [addTurno, setAddTurno] = useState(false)
   const [editTurnoId, setEditTurnoId] = useState<string | null>(null)
@@ -42,38 +58,30 @@ export default function Turnos() {
                 </tr>
               </thead>
               <tbody>
-                {turnos.map((t) => {
-                  const pac = pacientes.find((p) => p.id === t.pacienteId)
-                  const doc = doctores.find((d) => d.id === t.doctorId)
-                  return (
-                    <tr key={t.id} className="border-b hover:bg-gray-50">
-                      <td className="px-4 py-2">{t.fecha}</td>
-                      <td className="px-4 py-2">{t.hora}</td>
-                      <td className="px-4 py-2 capitalize">{t.tipo}</td>
-                      <td className="px-4 py-2">
-                        {pac?.nombre} {pac?.apellido}
-                      </td>
-                      <td className="px-4 py-2">
-                        {doc?.nombre} {doc?.apellido}
-                      </td>
-                      <td className="px-4 py-2">{t.descripcion}</td>
-                      <td className="px-4 py-2 space-x-2">
-                        <button
-                          onClick={() => setEditTurnoId(t.id)}
-                          className="text-sky-600 hover:underline"
-                        >
-                          Editar
-                        </button>
-                        <button
-                          onClick={() => eliminarTurno(t.id)}
-                          className="text-red-600 hover:underline"
-                        >
-                          Eliminar
-                        </button>
-                      </td>
-                    </tr>
-                  )
-                })}
+              {turnos.map((t) => (
+                <tr key={t.id} className="border-b hover:bg-gray-50">
+                  <td className="px-4 py-2">{t.fecha}</td>
+                  <td className="px-4 py-2">{t.hora}</td>
+                  <td className="px-4 py-2 capitalize">{t.tipo}</td>
+                  <td className="px-4 py-2">{pacienteMap[t.pacienteId]}</td>
+                  <td className="px-4 py-2">{doctorMap[t.doctorId]}</td>
+                  <td className="px-4 py-2">{t.descripcion}</td>
+                  <td className="px-4 py-2 space-x-2">
+                    <button
+                      onClick={() => setEditTurnoId(t.id)}
+                      className="text-sky-600 hover:underline"
+                    >
+                      Editar
+                    </button>
+                    <button
+                      onClick={() => eliminarTurno(t.id)}
+                      className="text-red-600 hover:underline"
+                    >
+                      Eliminar
+                    </button>
+                  </td>
+                </tr>
+              ))}
               </tbody>
             </table>
           </div>

--- a/M8MED/src/pages/Turnos.tsx
+++ b/M8MED/src/pages/Turnos.tsx
@@ -1,42 +1,44 @@
-import { useState, useMemo } from 'react'
-import Navbar from '../components/Navbar'
-import Modal from '../components/Modal'
-import FormTurno from '../components/FormTurno'
-import { useTurnoStore } from '../store/useTurnoStore'
-import { usePacienteStore } from '../store/usePacienteStore'
-import { useM8Store } from '../store/useM8Store'
+import { useState, useMemo } from 'react';
+import Navbar from '../components/Navbar';
+import Modal from '../components/Modal';
+import FormTurno from '../components/FormTurno';
+import { useTurnoStore } from '../store/useTurnoStore';
+import { usePacienteStore } from '../store/usePacienteStore';
+import { useM8Store } from '../store/useM8Store';
 
 export default function Turnos() {
-  const turnos = useTurnoStore((s) => s.turnos)
-  const eliminarTurno = useTurnoStore((s) => s.eliminarTurno)
-  const pacientes = usePacienteStore((s) => s.pacientes)
-  const doctores = useM8Store((s) => s.doctores)
+  const turnos = useTurnoStore((s) => s.turnos);
+  const eliminarTurno = useTurnoStore((s) => s.eliminarTurno);
+  const pacientes = usePacienteStore((s) => s.pacientes);
+  const doctores = useM8Store((s) => s.doctores);
 
   const pacienteMap = useMemo(() => {
-    const map: Record<string, string> = {}
+    const map: Record<string, string> = {};
     pacientes.forEach((p) => {
-      map[p.id] = `${p.nombre} ${p.apellido}`
-    })
-    return map
-  }, [pacientes])
+      map[p.id] = `${p.nombre} ${p.apellido}`;
+    });
+    return map;
+  }, [pacientes]);
 
   const doctorMap = useMemo(() => {
-    const map: Record<string, string> = {}
+    const map: Record<string, string> = {};
     doctores.forEach((d) => {
-      map[d.id] = `${d.nombre} ${d.apellido}`
-    })
-    return map
-  }, [doctores])
+      map[d.id] = `${d.nombre} ${d.apellido}`;
+    });
+    return map;
+  }, [doctores]);
 
-  const [addTurno, setAddTurno] = useState(false)
-  const [editTurnoId, setEditTurnoId] = useState<string | null>(null)
+  const [addTurno, setAddTurno] = useState(false);
+  const [editTurnoId, setEditTurnoId] = useState<string | null>(null);
 
   return (
     <>
       <Navbar />
       <header className="bg-white shadow">
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-          <h1 className="text-3xl font-bold tracking-tight text-gray-900">Turnos</h1>
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+            Turnos
+          </h1>
         </div>
       </header>
       <main>
@@ -46,51 +48,51 @@ export default function Turnos() {
               + Agregar turno
             </button>
           </div>
-        {turnos.length === 0 ? (
-          <p>No hay turnos registrados.</p>
-        ) : (
-          <div className="overflow-x-auto bg-white shadow rounded-lg">
-            <table className="min-w-full text-sm">
-              <thead className="bg-gray-100 text-gray-700 text-left">
-                <tr>
-                  <th className="px-4 py-2">Fecha</th>
-                  <th className="px-4 py-2">Hora</th>
-                  <th className="px-4 py-2">Tipo</th>
-                  <th className="px-4 py-2">Paciente</th>
-                  <th className="px-4 py-2">Médico</th>
-                  <th className="px-4 py-2">Descripción</th>
-                  <th className="px-4 py-2">Acciones</th>
-                </tr>
-              </thead>
-              <tbody>
-              {turnos.map((t) => (
-                <tr key={t.id} className="border-b hover:bg-gray-50">
-                  <td className="px-4 py-2">{t.fecha}</td>
-                  <td className="px-4 py-2">{t.hora}</td>
-                  <td className="px-4 py-2 capitalize">{t.tipo}</td>
-                  <td className="px-4 py-2">{pacienteMap[t.pacienteId]}</td>
-                  <td className="px-4 py-2">{doctorMap[t.doctorId]}</td>
-                  <td className="px-4 py-2">{t.descripcion}</td>
-                  <td className="px-4 py-2 space-x-2">
-                    <button
-                      onClick={() => setEditTurnoId(t.id)}
-                      className="text-sky-600 hover:underline"
-                    >
-                      Editar
-                    </button>
-                    <button
-                      onClick={() => eliminarTurno(t.id)}
-                      className="text-red-600 hover:underline"
-                    >
-                      Eliminar
-                    </button>
-                  </td>
-                </tr>
-              ))}
-              </tbody>
-            </table>
-          </div>
-        )}
+          {turnos.length === 0 ? (
+            <p>No hay turnos registrados.</p>
+          ) : (
+            <div className="overflow-x-auto bg-white shadow rounded-lg">
+              <table className="min-w-full text-sm">
+                <thead className="bg-gray-100 text-gray-700 text-left">
+                  <tr>
+                    <th className="px-4 py-2">Fecha</th>
+                    <th className="px-4 py-2">Hora</th>
+                    <th className="px-4 py-2">Tipo</th>
+                    <th className="px-4 py-2">Paciente</th>
+                    <th className="px-4 py-2">Médico</th>
+                    <th className="px-4 py-2">Descripción</th>
+                    <th className="px-4 py-2">Acciones</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {turnos.map((t) => (
+                    <tr key={t.id} className="border-b hover:bg-gray-50">
+                      <td className="px-4 py-2">{t.fecha}</td>
+                      <td className="px-4 py-2">{t.hora}</td>
+                      <td className="px-4 py-2 capitalize">{t.tipo}</td>
+                      <td className="px-4 py-2">{pacienteMap[t.pacienteId]}</td>
+                      <td className="px-4 py-2">{doctorMap[t.doctorId]}</td>
+                      <td className="px-4 py-2">{t.descripcion}</td>
+                      <td className="px-4 py-2 space-x-2">
+                        <button
+                          onClick={() => setEditTurnoId(t.id)}
+                          className="text-sky-600 hover:underline"
+                        >
+                          Editar
+                        </button>
+                        <button
+                          onClick={() => eliminarTurno(t.id)}
+                          className="text-red-600 hover:underline"
+                        >
+                          Eliminar
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       </main>
 
@@ -107,5 +109,5 @@ export default function Turnos() {
         )}
       </Modal>
     </>
-  )
+  );
 }

--- a/M8MED/src/pages/Turnos.tsx
+++ b/M8MED/src/pages/Turnos.tsx
@@ -34,13 +34,18 @@ export default function Turnos() {
   return (
     <>
       <Navbar />
-      <div className="max-w-5xl mx-auto p-6 pt-20">
-        <div className="flex justify-between items-center mb-6">
-          <h1 className="text-2xl font-bold">Turnos</h1>
-          <button className="btn" onClick={() => setAddTurno(true)}>
-            + Agregar turno
-          </button>
+      <header className="bg-white shadow">
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">Turnos</h1>
         </div>
+      </header>
+      <main>
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+          <div className="flex justify-end mb-4">
+            <button className="btn" onClick={() => setAddTurno(true)}>
+              + Agregar turno
+            </button>
+          </div>
         {turnos.length === 0 ? (
           <p>No hay turnos registrados.</p>
         ) : (
@@ -86,7 +91,8 @@ export default function Turnos() {
             </table>
           </div>
         )}
-      </div>
+        </div>
+      </main>
 
       <Modal isOpen={addTurno} onClose={() => setAddTurno(false)}>
         <FormTurno onFinish={() => setAddTurno(false)} />

--- a/M8MED/src/pages/Turnos.tsx
+++ b/M8MED/src/pages/Turnos.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+import Navbar from '../components/Navbar'
+import Modal from '../components/Modal'
+import FormTurno from '../components/FormTurno'
+import { useTurnoStore } from '../store/useTurnoStore'
+import { usePacienteStore } from '../store/usePacienteStore'
+import { useM8Store } from '../store/useM8Store'
+
+export default function Turnos() {
+  const turnos = useTurnoStore((s) => s.turnos)
+  const eliminarTurno = useTurnoStore((s) => s.eliminarTurno)
+  const pacientes = usePacienteStore((s) => s.pacientes)
+  const doctores = useM8Store((s) => s.doctores)
+
+  const [addTurno, setAddTurno] = useState(false)
+  const [editTurnoId, setEditTurnoId] = useState<string | null>(null)
+
+  return (
+    <>
+      <Navbar />
+      <div className="max-w-5xl mx-auto p-6 pt-20">
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-2xl font-bold">Turnos</h1>
+          <button className="btn" onClick={() => setAddTurno(true)}>
+            + Agregar turno
+          </button>
+        </div>
+        {turnos.length === 0 ? (
+          <p>No hay turnos registrados.</p>
+        ) : (
+          <div className="overflow-x-auto bg-white shadow rounded-lg">
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-100 text-gray-700 text-left">
+                <tr>
+                  <th className="px-4 py-2">Fecha</th>
+                  <th className="px-4 py-2">Hora</th>
+                  <th className="px-4 py-2">Paciente</th>
+                  <th className="px-4 py-2">Médico</th>
+                  <th className="px-4 py-2">Acciones</th>
+                </tr>
+              </thead>
+              <tbody>
+                {turnos.map((t) => {
+                  const pac = pacientes.find((p) => p.id === t.pacienteId)
+                  const doc = doctores.find((d) => d.id === t.doctorId)
+                  return (
+                    <tr key={t.id} className="border-b hover:bg-gray-50">
+                      <td className="px-4 py-2">{t.fecha}</td>
+                      <td className="px-4 py-2">{t.hora}</td>
+                      <td className="px-4 py-2">
+                        {pac?.nombre} {pac?.apellido}
+                      </td>
+                      <td className="px-4 py-2">
+                        {doc?.nombre} {doc?.apellido}
+                      </td>
+                      <td className="px-4 py-2 space-x-2">
+                        <button
+                          onClick={() => setEditTurnoId(t.id)}
+                          className="text-sky-600 hover:underline"
+                        >
+                          Editar
+                        </button>
+                        <button
+                          onClick={() => eliminarTurno(t.id)}
+                          className="text-red-600 hover:underline"
+                        >
+                          Eliminar
+                        </button>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <Modal isOpen={addTurno} onClose={() => setAddTurno(false)}>
+        <FormTurno onFinish={() => setAddTurno(false)} />
+      </Modal>
+
+      <Modal isOpen={editTurnoId !== null} onClose={() => setEditTurnoId(null)}>
+        {editTurnoId && (
+          <FormTurno
+            turno={turnos.find((t) => t.id === editTurnoId)}
+            onFinish={() => setEditTurnoId(null)}
+          />
+        )}
+      </Modal>
+    </>
+  )
+}

--- a/M8MED/src/routes/ProtectedRoute.tsx
+++ b/M8MED/src/routes/ProtectedRoute.tsx
@@ -1,17 +1,17 @@
-import { Navigate } from 'react-router-dom'
-import { useUserStore } from '../store/useUserStore'
+import { Navigate } from 'react-router-dom';
+import { useUserStore } from '../store/useUserStore';
 
 type Props = {
-  children: React.ReactNode
-  rolPermitido: ('admin' | 'medico') | Array<'admin' | 'medico'>
-}
+  children: React.ReactNode;
+  rolPermitido: ('admin' | 'medico') | Array<'admin' | 'medico'>;
+};
 
 export default function ProtectedRoute({ children, rolPermitido }: Props) {
-  const user = useUserStore((state) => state.user)
+  const user = useUserStore((state) => state.user);
 
-  if (!user) return <Navigate to="/" />
-  const roles = Array.isArray(rolPermitido) ? rolPermitido : [rolPermitido]
-  if (!roles.includes(user.rol)) return <Navigate to="/" />
+  if (!user) return <Navigate to="/" />;
+  const roles = Array.isArray(rolPermitido) ? rolPermitido : [rolPermitido];
+  if (!roles.includes(user.rol)) return <Navigate to="/" />;
 
-  return children
+  return children;
 }

--- a/M8MED/src/routes/ProtectedRoute.tsx
+++ b/M8MED/src/routes/ProtectedRoute.tsx
@@ -3,14 +3,15 @@ import { useUserStore } from '../store/useUserStore'
 
 type Props = {
   children: React.ReactNode
-  rolPermitido: 'admin' | 'medico'
+  rolPermitido: ('admin' | 'medico') | Array<'admin' | 'medico'>
 }
 
 export default function ProtectedRoute({ children, rolPermitido }: Props) {
   const user = useUserStore((state) => state.user)
 
   if (!user) return <Navigate to="/" />
-  if (user.rol !== rolPermitido) return <Navigate to="/" />
+  const roles = Array.isArray(rolPermitido) ? rolPermitido : [rolPermitido]
+  if (!roles.includes(user.rol)) return <Navigate to="/" />
 
   return children
 }

--- a/M8MED/src/store/useM8Store.ts
+++ b/M8MED/src/store/useM8Store.ts
@@ -7,6 +7,8 @@ export type Doctor = {
   nombre: string
   apellido: string
   email: string
+  password: string
+  foto: string
   telefono: string
   matricula: string
   especialidad: string
@@ -56,6 +58,8 @@ export const useM8Store = create<M8Store>()(
           nombre: 'Juan',
           apellido: 'Pérez',
           email: 'juan.perez@hospital.com',
+          password: '1234',
+          foto: 'https://placehold.co/64',
           telefono: '123456789',
           matricula: 'MP1001',
           especialidad: 'Cardiología',
@@ -67,6 +71,8 @@ export const useM8Store = create<M8Store>()(
           nombre: 'Ana',
           apellido: 'Gómez',
           email: 'ana.gomez@hospital.com',
+          password: '1234',
+          foto: 'https://placehold.co/64',
           telefono: '987654321',
           matricula: 'MP1002',
           especialidad: 'Traumatología',

--- a/M8MED/src/store/useM8Store.ts
+++ b/M8MED/src/store/useM8Store.ts
@@ -1,52 +1,52 @@
-import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
-import { v4 as uuidv4 } from 'uuid'
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { v4 as uuidv4 } from 'uuid';
 
 export type Doctor = {
-  id: string
-  nombre: string
-  apellido: string
-  email: string
-  password: string
-  foto: string
-  telefono: string
-  matricula: string
-  especialidad: string
-  sueldo: number
-  activo: boolean
-}
+  id: string;
+  nombre: string;
+  apellido: string;
+  email: string;
+  password: string;
+  foto: string;
+  telefono: string;
+  matricula: string;
+  especialidad: string;
+  sueldo: number;
+  activo: boolean;
+};
 
 export type Surgery = {
-  id: string
-  doctorId: string
-  fecha: string
-  hora: string
-  paciente: { nombre: string; dni: string }
-  diagnostico: string
-  tipo: string
-  complejidad: number
-  ayudantes: string[]
-  imagen?: string
-  valorBase: number
-}
+  id: string;
+  doctorId: string;
+  fecha: string;
+  hora: string;
+  paciente: { nombre: string; dni: string };
+  diagnostico: string;
+  tipo: string;
+  complejidad: number;
+  ayudantes: string[];
+  imagen?: string;
+  valorBase: number;
+};
 
-export type ComplejidadValores = { [nivel: number]: number }
+export type ComplejidadValores = { [nivel: number]: number };
 
 type M8Store = {
-  doctores: Doctor[]
-  cirugias: Surgery[]
-  complejidadValores: ComplejidadValores
-  agregarCirugia: (data: Omit<Surgery, 'id' | 'valorBase'>) => void
-  editarComplejidad: (nivel: number, valor: number) => void
-  agregarDoctor: (data: Omit<Doctor, 'sueldo' | 'activo'>) => void
+  doctores: Doctor[];
+  cirugias: Surgery[];
+  complejidadValores: ComplejidadValores;
+  agregarCirugia: (data: Omit<Surgery, 'id' | 'valorBase'>) => void;
+  editarComplejidad: (nivel: number, valor: number) => void;
+  agregarDoctor: (data: Omit<Doctor, 'sueldo' | 'activo'>) => void;
   editarDoctor: (
     id: string,
-    data: Omit<Doctor, 'id' | 'sueldo' | 'activo'>
-  ) => void
-  cambiarEstadoDoctor: (id: string, activo: boolean) => void
-  editarCirugia: (id: string, data: Omit<Surgery, 'id' | 'valorBase'>) => void
-  eliminarCirugia: (id: string) => void
-}
+    data: Omit<Doctor, 'id' | 'sueldo' | 'activo'>,
+  ) => void;
+  cambiarEstadoDoctor: (id: string, activo: boolean) => void;
+  editarCirugia: (id: string, data: Omit<Surgery, 'id' | 'valorBase'>) => void;
+  eliminarCirugia: (id: string) => void;
+};
 
 export const useM8Store = create<M8Store>()(
   persist(
@@ -96,116 +96,111 @@ export const useM8Store = create<M8Store>()(
       },
       agregarCirugia: (nueva) => {
         set((state) => {
-          const id = uuidv4()
-          const valorBase = state.complejidadValores[nueva.complejidad] ?? 0
-          const partes = 1 + nueva.ayudantes.length
-          const pagoPorMedico = valorBase / partes
+          const id = uuidv4();
+          const valorBase = state.complejidadValores[nueva.complejidad] ?? 0;
+          const partes = 1 + nueva.ayudantes.length;
+          const pagoPorMedico = valorBase / partes;
 
           const cirugia: Surgery = {
             ...nueva,
             id,
             valorBase,
-          }
+          };
 
           return {
             cirugias: [...state.cirugias, cirugia],
             doctores: state.doctores.map((doc) =>
               doc.id === nueva.doctorId || nueva.ayudantes.includes(doc.id)
                 ? { ...doc, sueldo: doc.sueldo + pagoPorMedico }
-                : doc
+                : doc,
             ),
-          }
-        })
+          };
+        });
       },
       editarComplejidad: (nivel, valor) => {
         set((state) => ({
           complejidadValores: { ...state.complejidadValores, [nivel]: valor },
-        }))
+        }));
       },
       agregarDoctor: (data) => {
         set((state) => ({
-          doctores: [
-            ...state.doctores,
-            { ...data, sueldo: 0, activo: true },
-          ],
-        }))
+          doctores: [...state.doctores, { ...data, sueldo: 0, activo: true }],
+        }));
       },
       editarDoctor: (id, data) => {
         set((state) => ({
           doctores: state.doctores.map((d) =>
-            d.id === id ? { ...d, ...data } : d
+            d.id === id ? { ...d, ...data } : d,
           ),
-        }))
+        }));
       },
       editarCirugia: (id, data) => {
         set((state) => {
-          const idx = state.cirugias.findIndex((c) => c.id === id)
-          if (idx === -1) return state
-          const anterior = state.cirugias[idx]
-          const valorPrev =
-            state.complejidadValores[anterior.complejidad] ?? 0
-          const partesPrev = 1 + anterior.ayudantes.length
-          const pagoPrev = valorPrev / partesPrev
+          const idx = state.cirugias.findIndex((c) => c.id === id);
+          if (idx === -1) return state;
+          const anterior = state.cirugias[idx];
+          const valorPrev = state.complejidadValores[anterior.complejidad] ?? 0;
+          const partesPrev = 1 + anterior.ayudantes.length;
+          const pagoPrev = valorPrev / partesPrev;
 
           let doctores = state.doctores.map((d) =>
             d.id === anterior.doctorId || anterior.ayudantes.includes(d.id)
               ? { ...d, sueldo: d.sueldo - pagoPrev }
-              : d
-          )
+              : d,
+          );
 
-          const valorNuevo =
-            state.complejidadValores[data.complejidad] ?? 0
-          const partesNuevo = 1 + data.ayudantes.length
-          const pagoNuevo = valorNuevo / partesNuevo
+          const valorNuevo = state.complejidadValores[data.complejidad] ?? 0;
+          const partesNuevo = 1 + data.ayudantes.length;
+          const pagoNuevo = valorNuevo / partesNuevo;
 
           doctores = doctores.map((d) =>
             d.id === data.doctorId || data.ayudantes.includes(d.id)
               ? { ...d, sueldo: d.sueldo + pagoNuevo }
-              : d
-          )
+              : d,
+          );
 
           const nuevaCirugia: Surgery = {
             ...data,
             id,
             valorBase: valorNuevo,
-          }
+          };
 
-          const nuevas = [...state.cirugias]
-          nuevas[idx] = nuevaCirugia
+          const nuevas = [...state.cirugias];
+          nuevas[idx] = nuevaCirugia;
 
-          return { cirugias: nuevas, doctores }
-        })
+          return { cirugias: nuevas, doctores };
+        });
       },
       eliminarCirugia: (id) => {
         set((state) => {
-          const cirugia = state.cirugias.find((c) => c.id === id)
-          if (!cirugia) return state
-          const valor = state.complejidadValores[cirugia.complejidad] ?? 0
-          const partes = 1 + cirugia.ayudantes.length
-          const pago = valor / partes
+          const cirugia = state.cirugias.find((c) => c.id === id);
+          if (!cirugia) return state;
+          const valor = state.complejidadValores[cirugia.complejidad] ?? 0;
+          const partes = 1 + cirugia.ayudantes.length;
+          const pago = valor / partes;
 
           return {
             cirugias: state.cirugias.filter((c) => c.id !== id),
             doctores: state.doctores.map((d) =>
               d.id === cirugia.doctorId || cirugia.ayudantes.includes(d.id)
                 ? { ...d, sueldo: d.sueldo - pago }
-                : d
+                : d,
             ),
-          }
-        })
+          };
+        });
       },
       cambiarEstadoDoctor: (id, activo) => {
         set((state) => ({
           doctores: state.doctores.map((d) =>
-            d.id === id ? { ...d, activo } : d
+            d.id === id ? { ...d, activo } : d,
           ),
-        }))
+        }));
       },
     }),
     {
       name: 'm8med-store', // clave de almacenamiento en localStorage
       // Sólo se guardan doctores, cirugías y complejidadValores; las funciones se mantienen.
       // Zustand se encarga de la hidratación automática al arrancar la app.
-    }
-  )
-)
+    },
+  ),
+);

--- a/M8MED/src/store/usePacienteStore.ts
+++ b/M8MED/src/store/usePacienteStore.ts
@@ -23,6 +23,7 @@ export const usePacienteStore = create<State>((set) => ({
       antecedentes: '',
       fechaNacimiento: '1980-05-10',
       tratamiento: 'Control mensual',
+      doctorId: 'doc1',
     },
     {
       id: 'pac2',
@@ -36,6 +37,7 @@ export const usePacienteStore = create<State>((set) => ({
       antecedentes: 'Familiar diabético',
       fechaNacimiento: '1975-10-20',
       tratamiento: 'Insulina',
+      doctorId: 'doc2',
     },
   ],
   setPacientes: (data) => set({ pacientes: data }),

--- a/M8MED/src/store/usePacienteStore.ts
+++ b/M8MED/src/store/usePacienteStore.ts
@@ -5,6 +5,8 @@ type State = {
   pacientes: Paciente[]
   setPacientes: (data: Paciente[]) => void
   agregarPaciente: (nuevo: Paciente) => void
+  editarPaciente: (id: string, data: Omit<Paciente, 'id'>) => void
+  eliminarPaciente: (id: string) => void
 }
 
 export const usePacienteStore = create<State>((set) => ({
@@ -39,4 +41,14 @@ export const usePacienteStore = create<State>((set) => ({
   setPacientes: (data) => set({ pacientes: data }),
   agregarPaciente: (nuevo) =>
     set((state) => ({ pacientes: [...state.pacientes, nuevo] })),
+  editarPaciente: (id, data) =>
+    set((state) => ({
+      pacientes: state.pacientes.map((p) =>
+        p.id === id ? { ...p, ...data } : p
+      ),
+    })),
+  eliminarPaciente: (id) =>
+    set((state) => ({
+      pacientes: state.pacientes.filter((p) => p.id !== id),
+    })),
 }))

--- a/M8MED/src/store/usePacienteStore.ts
+++ b/M8MED/src/store/usePacienteStore.ts
@@ -1,13 +1,13 @@
-import { create } from 'zustand'
-import type { Paciente } from '../types/paciente'
+import { create } from 'zustand';
+import type { Paciente } from '../types/paciente';
 
 type State = {
-  pacientes: Paciente[]
-  setPacientes: (data: Paciente[]) => void
-  agregarPaciente: (nuevo: Paciente) => void
-  editarPaciente: (id: string, data: Omit<Paciente, 'id'>) => void
-  eliminarPaciente: (id: string) => void
-}
+  pacientes: Paciente[];
+  setPacientes: (data: Paciente[]) => void;
+  agregarPaciente: (nuevo: Paciente) => void;
+  editarPaciente: (id: string, data: Omit<Paciente, 'id'>) => void;
+  eliminarPaciente: (id: string) => void;
+};
 
 export const usePacienteStore = create<State>((set) => ({
   pacientes: [
@@ -46,11 +46,11 @@ export const usePacienteStore = create<State>((set) => ({
   editarPaciente: (id, data) =>
     set((state) => ({
       pacientes: state.pacientes.map((p) =>
-        p.id === id ? { ...p, ...data } : p
+        p.id === id ? { ...p, ...data } : p,
       ),
     })),
   eliminarPaciente: (id) =>
     set((state) => ({
       pacientes: state.pacientes.filter((p) => p.id !== id),
     })),
-}))
+}));

--- a/M8MED/src/store/useTurnoStore.ts
+++ b/M8MED/src/store/useTurnoStore.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand'
+import { v4 as uuidv4 } from 'uuid'
+
+export type Turno = {
+  id: string
+  doctorId: string
+  pacienteId: string
+  fecha: string
+  hora: string
+}
+
+interface TurnoState {
+  turnos: Turno[]
+  agregarTurno: (t: Omit<Turno, 'id'>) => void
+  eliminarTurno: (id: string) => void
+}
+
+export const useTurnoStore = create<TurnoState>((set) => ({
+  turnos: [
+    {
+      id: 't1',
+      doctorId: 'doc1',
+      pacienteId: 'pac1',
+      fecha: '2025-08-01',
+      hora: '10:00',
+    },
+  ],
+  agregarTurno: (t) =>
+    set((state) => ({ turnos: [...state.turnos, { ...t, id: uuidv4() }] })),
+  eliminarTurno: (id) =>
+    set((state) => ({ turnos: state.turnos.filter((tu) => tu.id !== id) })),
+}))

--- a/M8MED/src/store/useTurnoStore.ts
+++ b/M8MED/src/store/useTurnoStore.ts
@@ -7,6 +7,8 @@ export type Turno = {
   pacienteId: string
   fecha: string
   hora: string
+  tipo: 'quirurgico' | 'consultorio'
+  descripcion: string
 }
 
 interface TurnoState {
@@ -24,6 +26,8 @@ export const useTurnoStore = create<TurnoState>((set) => ({
       pacienteId: 'pac1',
       fecha: '2025-08-01',
       hora: '10:00',
+      tipo: 'consultorio',
+      descripcion: 'Control de rutina',
     },
   ],
   agregarTurno: (t) =>

--- a/M8MED/src/store/useTurnoStore.ts
+++ b/M8MED/src/store/useTurnoStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 import { v4 as uuidv4 } from 'uuid'
 
 export type Turno = {
@@ -18,26 +19,31 @@ interface TurnoState {
   eliminarTurno: (id: string) => void
 }
 
-export const useTurnoStore = create<TurnoState>((set) => ({
-  turnos: [
-    {
-      id: 't1',
-      doctorId: 'doc1',
-      pacienteId: 'pac1',
-      fecha: '2025-08-01',
-      hora: '10:00',
-      tipo: 'consultorio',
-      descripcion: 'Control de rutina',
-    },
-  ],
-  agregarTurno: (t) =>
-    set((state) => ({ turnos: [...state.turnos, { ...t, id: uuidv4() }] })),
-  editarTurno: (id, data) =>
-    set((state) => ({
-      turnos: state.turnos.map((tu) =>
-        tu.id === id ? { ...tu, ...data } : tu
-      ),
-    })),
-  eliminarTurno: (id) =>
-    set((state) => ({ turnos: state.turnos.filter((tu) => tu.id !== id) })),
-}))
+export const useTurnoStore = create<TurnoState>()(
+  persist(
+    (set) => ({
+      turnos: [
+        {
+          id: 't1',
+          doctorId: 'doc1',
+          pacienteId: 'pac1',
+          fecha: '2025-08-01',
+          hora: '10:00',
+          tipo: 'consultorio',
+          descripcion: 'Control de rutina',
+        },
+      ],
+      agregarTurno: (t) =>
+        set((state) => ({ turnos: [...state.turnos, { ...t, id: uuidv4() }] })),
+      editarTurno: (id, data) =>
+        set((state) => ({
+          turnos: state.turnos.map((tu) =>
+            tu.id === id ? { ...tu, ...data } : tu
+          ),
+        })),
+      eliminarTurno: (id) =>
+        set((state) => ({ turnos: state.turnos.filter((tu) => tu.id !== id) })),
+    }),
+    { name: 'turno-store' }
+  )
+)

--- a/M8MED/src/store/useTurnoStore.ts
+++ b/M8MED/src/store/useTurnoStore.ts
@@ -12,6 +12,7 @@ export type Turno = {
 interface TurnoState {
   turnos: Turno[]
   agregarTurno: (t: Omit<Turno, 'id'>) => void
+  editarTurno: (id: string, data: Omit<Turno, 'id'>) => void
   eliminarTurno: (id: string) => void
 }
 
@@ -27,6 +28,12 @@ export const useTurnoStore = create<TurnoState>((set) => ({
   ],
   agregarTurno: (t) =>
     set((state) => ({ turnos: [...state.turnos, { ...t, id: uuidv4() }] })),
+  editarTurno: (id, data) =>
+    set((state) => ({
+      turnos: state.turnos.map((tu) =>
+        tu.id === id ? { ...tu, ...data } : tu
+      ),
+    })),
   eliminarTurno: (id) =>
     set((state) => ({ turnos: state.turnos.filter((tu) => tu.id !== id) })),
 }))

--- a/M8MED/src/store/useTurnoStore.ts
+++ b/M8MED/src/store/useTurnoStore.ts
@@ -1,22 +1,22 @@
-import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
-import { v4 as uuidv4 } from 'uuid'
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { v4 as uuidv4 } from 'uuid';
 
 export type Turno = {
-  id: string
-  doctorId: string
-  pacienteId: string
-  fecha: string
-  hora: string
-  tipo: 'quirurgico' | 'consultorio'
-  descripcion: string
-}
+  id: string;
+  doctorId: string;
+  pacienteId: string;
+  fecha: string;
+  hora: string;
+  tipo: 'quirurgico' | 'consultorio';
+  descripcion: string;
+};
 
 interface TurnoState {
-  turnos: Turno[]
-  agregarTurno: (t: Omit<Turno, 'id'>) => void
-  editarTurno: (id: string, data: Omit<Turno, 'id'>) => void
-  eliminarTurno: (id: string) => void
+  turnos: Turno[];
+  agregarTurno: (t: Omit<Turno, 'id'>) => void;
+  editarTurno: (id: string, data: Omit<Turno, 'id'>) => void;
+  eliminarTurno: (id: string) => void;
 }
 
 export const useTurnoStore = create<TurnoState>()(
@@ -38,12 +38,12 @@ export const useTurnoStore = create<TurnoState>()(
       editarTurno: (id, data) =>
         set((state) => ({
           turnos: state.turnos.map((tu) =>
-            tu.id === id ? { ...tu, ...data } : tu
+            tu.id === id ? { ...tu, ...data } : tu,
           ),
         })),
       eliminarTurno: (id) =>
         set((state) => ({ turnos: state.turnos.filter((tu) => tu.id !== id) })),
     }),
-    { name: 'turno-store' }
-  )
-)
+    { name: 'turno-store' },
+  ),
+);

--- a/M8MED/src/store/useUserStore.ts
+++ b/M8MED/src/store/useUserStore.ts
@@ -4,6 +4,7 @@ import { persist } from 'zustand/middleware'
 export type Rol = 'admin' | 'medico'
 
 type User = {
+  id?: string
   email: string
   rol: Rol
   nombre: string

--- a/M8MED/src/store/useUserStore.ts
+++ b/M8MED/src/store/useUserStore.ts
@@ -1,20 +1,35 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 export type Rol = 'admin' | 'medico'
 
 type User = {
-  email: string // CORREGIDO: Se usa email para consistencia con el login.
+  email: string
   rol: Rol
+  nombre: string
+  apellido: string
+  password: string
+  foto?: string
 }
 
 type Store = {
   user: User | null
   setUser: (user: User) => void
+  updateUser: (data: Partial<User>) => void
   logout: () => void
 }
 
-export const useUserStore = create<Store>((set) => ({
-  user: null,
-  setUser: (user) => set({ user }),
-  logout: () => set({ user: null }),
-}))
+export const useUserStore = create<Store>()(
+  persist(
+    (set) => ({
+      user: null,
+      setUser: (user) => set({ user }),
+      updateUser: (data) =>
+        set((state) =>
+          state.user ? { user: { ...state.user, ...data } } : { user: null }
+        ),
+      logout: () => set({ user: null }),
+    }),
+    { name: 'user-store' }
+  )
+)

--- a/M8MED/src/store/useUserStore.ts
+++ b/M8MED/src/store/useUserStore.ts
@@ -1,24 +1,24 @@
-import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
-export type Rol = 'admin' | 'medico'
+export type Rol = 'admin' | 'medico';
 
 type User = {
-  id?: string
-  email: string
-  rol: Rol
-  nombre: string
-  apellido: string
-  password: string
-  foto?: string
-}
+  id?: string;
+  email: string;
+  rol: Rol;
+  nombre: string;
+  apellido: string;
+  password: string;
+  foto?: string;
+};
 
 type Store = {
-  user: User | null
-  setUser: (user: User) => void
-  updateUser: (data: Partial<User>) => void
-  logout: () => void
-}
+  user: User | null;
+  setUser: (user: User) => void;
+  updateUser: (data: Partial<User>) => void;
+  logout: () => void;
+};
 
 export const useUserStore = create<Store>()(
   persist(
@@ -27,10 +27,10 @@ export const useUserStore = create<Store>()(
       setUser: (user) => set({ user }),
       updateUser: (data) =>
         set((state) =>
-          state.user ? { user: { ...state.user, ...data } } : { user: null }
+          state.user ? { user: { ...state.user, ...data } } : { user: null },
         ),
       logout: () => set({ user: null }),
     }),
-    { name: 'user-store' }
-  )
-)
+    { name: 'user-store' },
+  ),
+);

--- a/M8MED/src/types/paciente.ts
+++ b/M8MED/src/types/paciente.ts
@@ -1,14 +1,14 @@
 export type Paciente = {
-  id: string
-  nombre: string
-  apellido: string
-  dni: string
-  telefono: string
-  genero: 'masculino' | 'femenino' | 'otro'
-  email: string
-  diagnostico: string
-  antecedentes?: string
-  fechaNacimiento: string // formato ISO
-  tratamiento: string
-  doctorId: string
-}
+  id: string;
+  nombre: string;
+  apellido: string;
+  dni: string;
+  telefono: string;
+  genero: 'masculino' | 'femenino' | 'otro';
+  email: string;
+  diagnostico: string;
+  antecedentes?: string;
+  fechaNacimiento: string; // formato ISO
+  tratamiento: string;
+  doctorId: string;
+};

--- a/M8MED/src/types/paciente.ts
+++ b/M8MED/src/types/paciente.ts
@@ -10,4 +10,5 @@ export type Paciente = {
   antecedentes?: string
   fechaNacimiento: string // formato ISO
   tratamiento: string
+  doctorId: string
 }


### PR DESCRIPTION
## Summary
- extend patient store with edit and delete actions
- support editing patients in `FormPaciente`
- allow removing and editing patients from the list
- add edit patient page and routing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887521585d4832183c2c161c92522d0